### PR TITLE
switch from bitbucket to github in the docs

### DIFF
--- a/doc/python/source/about.rst
+++ b/doc/python/source/about.rst
@@ -5,7 +5,7 @@ The Remote Sensing and Geographical Information Systems software Library (RSGISL
 
 `Dan Clewley <http://mixil.usc.edu/people/staff/daniel-clewley.htm>`_ joined the project in December 2008, shortly after starting his PhD within DGES, at Aberystwyth University (funded by a NERC studentship).
 
-Features were added to RSGISLib, as required by Pete and Dan or requested by other researches and students within Aberystwyth University and collaborators in other institutions. 
+Features were added to RSGISLib, as required by Pete and Dan or requested by other researches and students within Aberystwyth University and collaborators in other institutions.
 
 The project was released under the GPL license in November 2009 in the hope it would be useful to others working in remote sensing and GIS and has been actively developed since then. Currently there are over 300 commands to perform a number of tasks.
 
@@ -47,7 +47,7 @@ Bibtex::
 
 **How do I cite RSGISLib?**
 
-If you have used RSGISLib for published work then you should cite the following publication and / or the specific paper of the algorithm you used (if applicable). 
+If you have used RSGISLib for published work then you should cite the following publication and / or the specific paper of the algorithm you used (if applicable).
 
 Peter Bunting, Daniel Clewley, Richard M. Lucas and Sam Gillingham. 2014. The Remote Sensing and GIS Software Library (RSGISLib), Computers & Geosciences. Volume 62, Pages 216-226 http://dx.doi.org/10.1016/j.cageo.2013.08.007.
 
@@ -61,7 +61,7 @@ Bibtex::
     	Volume = {62},
     	Year = {2014}}
 
-    
+
 **Is RSGISLib intended to be a substitute for commercial GIS / RS packages or other open source packages?**
 
 No, RSGISLib is not being developed as a substitute for ArcMap / QGIS or ENVI. As stated above, RSGISLib is mainly developed to support our research, because of this there is a lot of advanced functionality in RSGISLib that is unavailable in other packages. Although RSGISLib works well on the desktop, it scales well to a High Performance Computing (HPC) environment, which is an area many of the previously mentioned software aren't focusing on.
@@ -78,8 +78,8 @@ The RSGISLib documentation, which contains tutorials for selected functions is a
 
 Help is available for RSGISLib through emailing our mailing list: rsgislib-support@googlegroups.com
 
-The archive is available to view at `groups.google.com <https://groups.google.com/forum/#!forum/rsgislib-support>`_ 
- 
+The archive is available to view at `groups.google.com <https://groups.google.com/forum/#!forum/rsgislib-support>`_
+
 **Do you offer training on RSGISLib?**
 
 RSGISLib is taught as part of the Masters course at Aberystwyth University. The notes for the Python course, which include a chapter using RSGISLib for object based classification are available `bitbucket.org/petebunting/python-tutorial-for-spatial-data-processing <https://bitbucket.org/petebunting/python-tutorial-for-spatial-data-processing>`_. We gave a training course at the 20th JAXA Kyoto & Carbon initiative meeting on object based classification, the notes are available to download from `Sourceforge <https://sourceforge.net/projects/rsgislib/files/Training/JAXA_GMW_RSGISLibCourse.zip>`_.
@@ -90,7 +90,7 @@ If you are interested in training sessions, please contact us.
 
 **How do I go about getting functionality added to RSGISLib?**
 
-For general suggestions submit a ticket on our `issues <https://bitbucket.org/petebunting/rsgislib/issues?status=new&status=open>`_ page on Bitbucket or post a suggestion to the Google groups mailing list. 
+For general suggestions submit a ticket on our `issues <https://github.com/remotesensinginfo/rsgislib/issues?status=new&status=open>`_ page on GitHub or post a suggestion to the Google groups mailing list.
 
 If you are preparing a research proposal or have a commercial project where you are likely use RSGISLib please contact us for collaborative opportunities or consultancy work to add new functions to RSGISLib, improve existing features or build custom software on top of RSGISLib.
 

--- a/doc/python/source/download.rst
+++ b/doc/python/source/download.rst
@@ -6,13 +6,13 @@ Docker and Singularity
 
 The simplest way to download and use RSGISLib and associated packages is via Docker (https://www.docker.com). We provide stable and development Docker images:
 
-* Stable: petebunting/au-eoed 
+* Stable: petebunting/au-eoed
 * Development: petebunting/au-eoed-dev
 
 .. code-block:: bash
 
-    docker pull petebunting/au-eoed 
-    # Note. for commands below all data and script need to be available in your 
+    docker pull petebunting/au-eoed
+    # Note. for commands below all data and script need to be available in your
     # local directory and to be referenced from the /data path.
     # Run your rsgislib python script
     docker run -i -t -v ${PWD}:/data petebunting/au-eoed python /data/my_rsgislib_script.py
@@ -21,12 +21,12 @@ The simplest way to download and use RSGISLib and associated packages is via Doc
     # Gain access to the docker image terminal
     docker run -i -t -v ${PWD}:/data petebunting/au-eoed /bin/bash
 
-For HPC users Docker cannot be used as it requires to execute as root user. However, Singularity (https://sylabs.io) allows Docker images to be imported and executed as a local user. 
+For HPC users Docker cannot be used as it requires to execute as root user. However, Singularity (https://sylabs.io) allows Docker images to be imported and executed as a local user.
 
 .. code-block:: bash
 
     singularity pull docker://petebunting/au-eoed
-    # Note. Singularity has the advantage that is can use local paths and does not 
+    # Note. Singularity has the advantage that is can use local paths and does not
     # need to mount the file system to access file.
     # Run your rsgislib python script
     singularity exec au-eoed.simg python my_rsgislib_script.py
@@ -45,7 +45,7 @@ The recomended way to install RSGISlib locally is from conda-forge using the fol
     conda create -n osgeo-env-v1 python=3.7
     source activate osgeo-env-v1
     conda install -c conda-forge rsgislib
-    
+
 The following video shows the steps to undertake this installation.
 
 .. youtube:: 9HqKLioyAeM
@@ -54,12 +54,12 @@ The following video shows the steps to undertake this installation.
 Source
 -------
 
-The RSGISLib source is available to download from  https://bitbucket.org/petebunting/rsgislib . Releases are available from the downloads tab, for the latest version of RSGISLib you can check out the development version with mercurial using:
+The RSGISLib source is available to download from  https://github.com/remotesensinginfo/rsgislib . Releases are available from the **tags** tab, for the latest version of RSGISLib you can check out the development version with mercurial using:
 
 .. code-block:: bash
 
-    hg clone https://bitbucket.org/petebunting/rsgislib rsgislib-code
-    
+    git clone https://github.com/remotesensinginfo/rsgislib rsgislib-code
+
 
 We have also created spack (https://spack.readthedocs.io) build instructions, which are updated on an adhoc basis. See https://github.com/spack/spack for spack source.
 
@@ -68,5 +68,5 @@ For help with compiling or downloading RSGISLib you can email our mailing list:
 
 rsgislib-support@googlegroups.com
 
-The archives can be accessed at: 
+The archives can be accessed at:
 https://groups.google.com/forum/#!forum/rsgislib-support

--- a/doc/python/source/index.rst
+++ b/doc/python/source/index.rst
@@ -9,7 +9,7 @@ The Remote Sensing and GIS Software Library (RSGISLib)
 ========================================================
 The Remote Sensing and GIS software library (RSGISLib) is a collection of tools for processing remote sensing and GIS datasets. The tools are accessed using Python bindings.
 
-The project is hosted on Bitbucket and is available to download from https://bitbucket.org/petebunting/rsgislib 
+The project is hosted on GitHub and is available to download from https://github.com/remotesensinginfo/rsgislib 
 
 The project is jointly led by Pete Bunting (`Earth Observation and Ecosystem Dynamics Group <http://www.aber.ac.uk/en/iges/research-groups/earth-observation-laboratory/>`_ , `Aberystwyth University <http://www.aber.ac.uk/>`_) and Dan Clewley (`Plymouth Marine Laboratory <http://pml.ac.uk>`_).
 


### PR DESCRIPTION
👋 sorry for the unsolicited PR. 

This PR does fix the old bitbucket references in the documentation. There are still broken links to the different python tutorials but I couldn't find the new location for those. 