### PR TITLE
.deb package building for ubuntu 20.04 with ubuntugis

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+docker/Dockerfile

--- a/contrib/ubuntu/README.md
+++ b/contrib/ubuntu/README.md
@@ -13,3 +13,8 @@ This creates a docker image which should have the debian built in /usr/local/pac
 The process relies on fetching and installing a companian .deb of kealib to build against. This is hosted by Environment Systems Ltd in a public S3 Bucket. This part of the build could be replaced by building from source locally if required. 
 
 The built .deb package requires RIOS to run properly. This can be installed into your python environment in the normal way, no extra packaging is supplied.
+
+Copies of packages generated as above are hosted by Environment Systems Ltd (no warranty express or implied) at:
+
+ - https://envsys-public.s3.amazonaws.com/ubuntu/rsgislib/focal_ubuntugis_stable_rsgislib_5.0.5-1.deb
+ - https://envsys-public.s3.amazonaws.com/ubuntu/rsgislib/focal_ubuntugis_unstable_rsgislib_5.0.5-1.deb

--- a/contrib/ubuntu/README.md
+++ b/contrib/ubuntu/README.md
@@ -1,0 +1,15 @@
+# To build .deb packages
+
+Run the following command **from the root of the repository**
+
+`docker build . -f contrib/ubuntu/focal_ubuntugis_stable/Dockerfile -t rsgislib_focal_deb_builder`
+
+This creates a docker image which should have the debian built in /usr/local/packages from where you can copy it out, e.g.,
+
+`docker run --rm --entrypoint cat rsgislib_focal_deb_builder /usr/local/packages/rsgislib_5.0.5-1.deb > /tmp/rsgislib_5.0.5-1.deb`
+
+## Notes:
+
+The process relies on fetching and installing a companian .deb of kealib to build against. This is hosted by Environment Systems Ltd in a public S3 Bucket. This part of the build could be replaced by building from source locally if required. 
+
+The built .deb package requires RIOS to run properly. This can be installed into your python environment in the normal way, no extra packaging is supplied.

--- a/contrib/ubuntu/focal_ubuntugis_stable/DEBIAN/control
+++ b/contrib/ubuntu/focal_ubuntugis_stable/DEBIAN/control
@@ -1,0 +1,10 @@
+Package: rsgislib
+Version: 5.0.5-1
+Section: science
+Priority: optional
+Architecture: amd64
+Depends: libkea, libgdal29, libboost-filesystem1.71.0, libboost-date-time1.71.0, libboost-thread1.71.0, libgsl23, libmuparser2v5, libhdf5-cpp-103
+Maintainer: Environment Systems Ltd. (developers@envsys.co.uk)
+Description: The Raster GIS Library by Pete Bunting et al.
+ A collection of tools for processing remote sensing and GIS datasets. 
+ For more details see the project website: http://rsgislib.org/

--- a/contrib/ubuntu/focal_ubuntugis_stable/Dockerfile
+++ b/contrib/ubuntu/focal_ubuntugis_stable/Dockerfile
@@ -1,0 +1,84 @@
+#
+# This creates an Ubuntu derived base image to build
+# RSGISLib and package it as .deb
+# 
+# NOTE: The built package is designed to work on ubuntu focal with ubuntu-gis stable PPA
+# This is for the updated gdal versions available within that PPA.
+#
+# Ubuntu 20.04 Bionic Beaver
+FROM ubuntu:focal
+
+MAINTAINER EnvSys <developers@envsys.co.uk>
+
+ENV ROOTDIR /usr/local/
+
+ENV TZ=Europe/London
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+# Load assets
+WORKDIR $ROOTDIR/
+
+# Install basic dependencies
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends software-properties-common && \
+    add-apt-repository universe && \
+    add-apt-repository -y ppa:ubuntugis/ppa && \
+    apt-get update -y && apt-get install --no-install-recommends -y \
+    build-essential \
+    python3-dev \
+    python3-setuptools \
+    libgdal-dev \
+    libhdf5-serial-dev \
+    libgsl-dev \
+    libgsl23 \
+    libgmp-dev \
+    libboost-filesystem-dev \
+    libboost-date-time-dev \
+    libboost-thread-dev \
+    libmpfr-dev \
+    libmuparser-dev \
+    libmuparser2v5 \
+    libhdf5-dev \
+    wget \
+    locales \
+    cmake
+
+ARG KEALIB_DEB_URL=https://envsys-public.s3.amazonaws.com/ubuntu/kealib/focal_ubuntugis_stable_libkea_1.4.14-1.deb
+ARG RSGISLIB_VER=5.0.5
+ARG PACKAGE_DIR=/usr/local/packages
+ARG RSGSILIB_PACKAGE_DIR=$PACKAGE_DIR/rsgislib_$RSGISLIB_VER-1
+ARG make_threads=7
+
+# Install kealib
+RUN cd /usr/local/src && \
+    wget $KEALIB_DEB_URL && \
+    dpkg -i *libkea*.deb && \
+    ldconfig
+
+# Install rsgislib
+RUN mkdir /usr/local/src/rsgislib
+COPY . /usr/local/src/rsgislib
+
+RUN mkdir -p $RSGSILIB_PACKAGE_DIR
+
+RUN cd /usr/local/src/rsgislib && \
+    cmake \
+    -D GDAL_INCLUDE_DIR=/usr/include/gdal \
+    -D GDAL_LIB_PATH=/usr/lib/gdal \
+    -D HDF5_INCLUDE_DIR=/usr/include/hdf5/serial \
+    -D HDF5_LIB_PATH=/usr/lib/x86_64-linux-gnu/hdf5/serial \
+    -D CMAKE_VERBOSE_MAKEFILE=ON \
+    -D CMAKE_INSTALL_PREFIX=/usr \
+    . && \
+    make -j "${make_threads}" && \
+    make install DESTDIR=$RSGSILIB_PACKAGE_DIR && \
+    make install && \
+    ldconfig && \
+    mkdir -p $RSGSILIB_PACKAGE_DIR/usr/lib/python3.8/dist-packages/rsgislib-$RSGISLIB_VER.dist-info && \
+    touch $RSGSILIB_PACKAGE_DIR/usr/lib/python3.8/dist-packages/rsgislib-$RSGISLIB_VER.dist-info/METADATA
+    
+RUN mkdir $RSGSILIB_PACKAGE_DIR/DEBIAN
+COPY ./contrib/ubuntu/focal_ubuntugis_stable/DEBIAN $RSGSILIB_PACKAGE_DIR/DEBIAN
+RUN dpkg-deb --build $RSGSILIB_PACKAGE_DIR
+
+

--- a/contrib/ubuntu/focal_ubuntugis_unstable/DEBIAN/control
+++ b/contrib/ubuntu/focal_ubuntugis_unstable/DEBIAN/control
@@ -1,0 +1,10 @@
+Package: rsgislib
+Version: 5.0.5-1
+Section: science
+Priority: optional
+Architecture: amd64
+Depends: libkea, libgdal30, libboost-filesystem1.71.0, libboost-date-time1.71.0, libboost-thread1.71.0, libgsl23, libmuparser2v5, libhdf5-cpp-103
+Maintainer: Environment Systems Ltd. (developers@envsys.co.uk)
+Description: The Raster GIS Library by Pete Bunting et al.
+ A collection of tools for processing remote sensing and GIS datasets. 
+ For more details see the project website: http://rsgislib.org/

--- a/contrib/ubuntu/focal_ubuntugis_unstable/Dockerfile
+++ b/contrib/ubuntu/focal_ubuntugis_unstable/Dockerfile
@@ -1,0 +1,84 @@
+#
+# This creates an Ubuntu derived base image to build
+# RSGISLib and package it as .deb
+# 
+# NOTE: The built package is designed to work on ubuntu focal with ubuntu-gis stable PPA
+# This is for the updated gdal versions available within that PPA.
+#
+# Ubuntu 20.04 Bionic Beaver
+FROM ubuntu:focal
+
+MAINTAINER EnvSys <developers@envsys.co.uk>
+
+ENV ROOTDIR /usr/local/
+
+ENV TZ=Europe/London
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+# Load assets
+WORKDIR $ROOTDIR/
+
+# Install basic dependencies
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends software-properties-common && \
+    add-apt-repository universe && \
+    add-apt-repository -y ppa:ubuntugis/ubuntugis-unstable && \
+    apt-get update -y && apt-get install --no-install-recommends -y \
+    build-essential \
+    python3-dev \
+    python3-setuptools \
+    libgdal-dev \
+    libhdf5-serial-dev \
+    libgsl-dev \
+    libgsl23 \
+    libgmp-dev \
+    libboost-filesystem-dev \
+    libboost-date-time-dev \
+    libboost-thread-dev \
+    libmpfr-dev \
+    libmuparser-dev \
+    libmuparser2v5 \
+    libhdf5-dev \
+    wget \
+    locales \
+    cmake
+
+ARG KEALIB_DEB_URL=https://envsys-public.s3.amazonaws.com/ubuntu/kealib/focal_ubuntugis_unstable_libkea_1.4.14-1.deb
+ARG RSGISLIB_VER=5.0.5
+ARG PACKAGE_DIR=/usr/local/packages
+ARG RSGSILIB_PACKAGE_DIR=$PACKAGE_DIR/rsgislib_$RSGISLIB_VER-1
+ARG make_threads=7
+
+# Install kealib
+RUN cd /usr/local/src && \
+    wget $KEALIB_DEB_URL && \
+    dpkg -i *libkea*.deb && \
+    ldconfig
+
+# Install rsgislib
+RUN mkdir /usr/local/src/rsgislib
+COPY . /usr/local/src/rsgislib
+
+RUN mkdir -p $RSGSILIB_PACKAGE_DIR
+
+RUN cd /usr/local/src/rsgislib && \
+    cmake \
+    -D GDAL_INCLUDE_DIR=/usr/include/gdal \
+    -D GDAL_LIB_PATH=/usr/lib/gdal \
+    -D HDF5_INCLUDE_DIR=/usr/include/hdf5/serial \
+    -D HDF5_LIB_PATH=/usr/lib/x86_64-linux-gnu/hdf5/serial \
+    -D CMAKE_VERBOSE_MAKEFILE=ON \
+    -D CMAKE_INSTALL_PREFIX=/usr \
+    . && \
+    make -j "${make_threads}" && \
+    make install DESTDIR=$RSGSILIB_PACKAGE_DIR && \
+    make install && \
+    ldconfig && \
+    mkdir -p $RSGSILIB_PACKAGE_DIR/usr/lib/python3.8/dist-packages/rsgislib-$RSGISLIB_VER.dist-info && \
+    touch $RSGSILIB_PACKAGE_DIR/usr/lib/python3.8/dist-packages/rsgislib-$RSGISLIB_VER.dist-info/METADATA
+    
+RUN mkdir $RSGSILIB_PACKAGE_DIR/DEBIAN
+COPY ./contrib/ubuntu/focal_ubuntugis_unstable/DEBIAN $RSGSILIB_PACKAGE_DIR/DEBIAN
+RUN dpkg-deb --build $RSGSILIB_PACKAGE_DIR
+
+


### PR DESCRIPTION
This PR introduces a docker driven process to build .deb packages for ubuntu 20.04 with the ubuntugis PPA (stable and unstable).

We find this useful for our own packaging and install requirements, if you think it could be of wider benefit, please merge.