### PR TITLE
Clearsky fix

### DIFF
--- a/python/rsgislib/imagecalc/__init__.py
+++ b/python/rsgislib/imagecalc/__init__.py
@@ -173,7 +173,7 @@ def calc_dist_to_img_vals(
         dist2Clouds = 'LS5TM_20110701_lat52lon421_r24p204_distclouds.kea'
         # Pixel value 1 == Clouds
         # Pixel value 2 == Cloud Shadows
-        rsgislib.imagecalc.calc_dist_to_img_vals(cloudsImg, dist2Clouds, pxl_vals=[1,2])
+        rsgislib.imagecalc.calc_dist_to_img_vals(cloudsImg, dist2Clouds, pxl_vals=[1,2], out_no_data_val=-9999)
 
     """
     # Check gdal is available
@@ -217,6 +217,8 @@ def calc_dist_to_img_vals(
 
     if out_no_data_val is None:
         out_no_data_val = max_dist
+    if out_no_data_val is None:
+        raise ValueError("Either out_no_data_val or max_dist must be supplied.")
 
     valsImgDS = gdal.Open(input_img, gdal.GA_ReadOnly)
     valsImgBand = valsImgDS.GetRasterBand(img_band)

--- a/python/rsgislib/imagecalibration/__init__.py
+++ b/python/rsgislib/imagecalibration/__init__.py
@@ -229,7 +229,7 @@ def calc_clear_sky_regions(
     tmpMorphOperator = os.path.join(tmpPath, "CircularMorphOp.gmtxt")
 
     rsgislib.imagecalc.calc_dist_to_img_vals(
-        cloudsImg, tmpCloudsImgDist2Clouds, pxl_vals=[1, 2]
+        cloudsImg, tmpCloudsImgDist2Clouds, pxl_vals=[1, 2], out_no_data_val=-9999
     )
 
     rsgislib.imageutils.mask_img(

--- a/python/rsgislib/imagecalibration/__init__.py
+++ b/python/rsgislib/imagecalibration/__init__.py
@@ -229,7 +229,7 @@ def calc_clear_sky_regions(
     tmpMorphOperator = os.path.join(tmpPath, "CircularMorphOp.gmtxt")
 
     rsgislib.imagecalc.calc_dist_to_img_vals(
-        cloudsImg, tmpCloudsImgDist2Clouds, pxlVals=[1, 2]
+        cloudsImg, tmpCloudsImgDist2Clouds, pxl_vals=[1, 2]
     )
 
     rsgislib.imageutils.mask_img(
@@ -291,7 +291,7 @@ def calc_clear_sky_regions(
     rsgislib.rastergis.populate_rat_with_stats(
         tmpInitClearSkyRegionsFinal,
         tmpClearSkyRegionsFullExtentClumps,
-        [rsgislib.rastergis.BandAttStats(band=1, maxField="InitRegionInter")],
+        [rsgislib.rastergis.BandAttStats(band=1, max_field="InitRegionInter")],
     )
 
     ratDataset = gdal.Open(tmpClearSkyRegionsFullExtentClumps, gdal.GA_Update)
@@ -314,16 +314,16 @@ def calc_clear_sky_regions(
     )
 
     rsgislib.imagemorphology.create_circular_op(
-        outputFile=tmpMorphOperator, opSize=morphSize
+        output_file=tmpMorphOperator, op_size=morphSize
     )
 
     rsgislib.imagemorphology.image_opening(
-        inputImage=tmpClearSkyRegionsFullExtentSelectClumps,
-        outputImage=tmpClearSkyRegionsFullExtentSelectClumpsOpen,
-        tempImage="",
-        morphOperator=tmpMorphOperator,
-        useOpFile=True,
-        opSize=21,
+        input_img=tmpClearSkyRegionsFullExtentSelectClumps,
+        output_img=tmpClearSkyRegionsFullExtentSelectClumpsOpen,
+        tmp_img="",
+        morph_op_file=tmpMorphOperator,
+        use_op_file=True,
+        op_size=21,
         gdalformat="KEA",
         datatype=rsgislib.TYPE_32UINT,
     )


### PR DESCRIPTION
This PR addresses #35.

We use the `calc_clear_sky_regions` routine as part of the cloud masking process of Sentinel 2 data. We have tested this branch as working in that capacity.