### PR TITLE
Updated for RIOS v2

### DIFF
--- a/python/rsgislib/__init__.py
+++ b/python/rsgislib/__init__.py
@@ -720,6 +720,7 @@ class TQDMProgressBar:
 
     def reset(self):
         import tqdm
+
         if self.pbar is not None:
             self.pbar.close()
 

--- a/python/rsgislib/changedetect/pxloutlierchng.py
+++ b/python/rsgislib/changedetect/pxloutlierchng.py
@@ -37,7 +37,7 @@
 from __future__ import print_function
 
 import numpy
-from rios import applier, cuiprogress
+from rios import applier
 
 import rsgislib
 import rsgislib.imagecalc
@@ -67,7 +67,7 @@ def find_class_pyod_outliers(
     This function uses the pyod (https://github.com/yzhao062/pyod) library to
     find outliers within a class. It is assumed that the input images are from a
     different date than the mask (classification) and therefore the outliers will
-    related to class changes.
+    be related to class changes.
 
     :param pyod_obj: an instance of a pyod.models (e.g., pyod.models.knn.KNN) pass
                      parameters to the constructor
@@ -86,14 +86,14 @@ def find_class_pyod_outliers(
 
     """
     if img_bands is not None:
-        if not ((type(img_bands) is list) or (type(img_bands) is tuple)):
+        if not (isinstance(img_bands, list) or isinstance(img_bands, tuple)):
             raise rsgislib.RSGISPyException(
                 "If provided then img_bands should be a list (or None)"
             )
     else:
         n_bands = rsgislib.imageutils.get_img_band_count(input_img)
         img_bands = numpy.arange(1, n_bands + 1)
-    num_vars = len(img_bands)
+
     img_val_no_data = rsgislib.imageutils.get_img_no_data_value(input_img)
 
     msk_arr_vals = rsgislib.imageutils.extract_img_pxl_vals_in_msk(

--- a/python/rsgislib/changedetect/pxloutlierchng.py
+++ b/python/rsgislib/changedetect/pxloutlierchng.py
@@ -49,6 +49,7 @@ try:
     import tqdm
 except ImportError:
     import rios.cuiprogress
+
     TQDM_AVAIL = False
 
 

--- a/python/rsgislib/changedetect/pxloutlierchng.py
+++ b/python/rsgislib/changedetect/pxloutlierchng.py
@@ -44,6 +44,13 @@ import rsgislib.imagecalc
 import rsgislib.imageutils
 import rsgislib.rastergis
 
+TQDM_AVAIL = True
+try:
+    import tqdm
+except ImportError:
+    import rios.cuiprogress
+    TQDM_AVAIL = False
+
 
 def find_class_pyod_outliers(
     pyod_obj,
@@ -184,12 +191,10 @@ def find_class_pyod_outliers(
         outfiles.out_scores_img = out_scores_img
         otherargs.out_scores = True
 
-    try:
-        import tqdm
-
+    if TQDM_AVAIL:
         progress_bar = rsgislib.TQDMProgressBar()
-    except:
-        progress_bar = cuiprogress.GDALProgressBar()
+    else:
+        progress_bar = rios.cuiprogress.GDALProgressBar()
 
     aControls = applier.ApplierControls()
     aControls.progress = progress_bar

--- a/python/rsgislib/classification/__init__.py
+++ b/python/rsgislib/classification/__init__.py
@@ -9,6 +9,13 @@ import rsgislib
 import rsgislib.imageutils
 from rsgislib.imageutils import ImageBandInfo
 
+TQDM_AVAIL = True
+try:
+    import tqdm
+except ImportError:
+    import rios.cuiprogress
+    TQDM_AVAIL = False
+
 # import the C++ extension into this level
 from ._classification import *
 
@@ -1413,12 +1420,10 @@ def fill_class_timeseries(
     other_args.n_imgs = len(input_imgs)
     other_args.n_iters = n_iters
 
-    try:
-        import tqdm
-
+    if TQDM_AVAIL:
         progress_bar = rsgislib.TQDMProgressBar()
-    except:
-        progress_bar = cuiprogress.GDALProgressBar()
+    else:
+        progress_bar = rios.cuiprogress.GDALProgressBar()
 
     a_controls = applier.ApplierControls()
     a_controls.progress = progress_bar

--- a/python/rsgislib/classification/__init__.py
+++ b/python/rsgislib/classification/__init__.py
@@ -14,6 +14,7 @@ try:
     import tqdm
 except ImportError:
     import rios.cuiprogress
+
     TQDM_AVAIL = False
 
 # import the C++ extension into this level

--- a/python/rsgislib/classification/__init__.py
+++ b/python/rsgislib/classification/__init__.py
@@ -2,7 +2,10 @@
 """
 The classification module provides classification functionality within RSGISLib.
 """
+# import the C++ extension into this level
+from ._classification import *
 
+import os
 from typing import Dict, List
 
 import rsgislib
@@ -16,9 +19,6 @@ except ImportError:
     import rios.cuiprogress
 
     TQDM_AVAIL = False
-
-# import the C++ extension into this level
-from ._classification import *
 
 
 class ClassSimpleInfoObj(object):
@@ -250,8 +250,6 @@ def get_class_info_dict(
              instance as the value.
 
     """
-    import os
-
     import rsgislib.tools.filetools
 
     cls_smpls_fnl_info = dict()
@@ -308,7 +306,6 @@ def get_class_training_data(
     :return: dictionary of ClassSimpleInfoObj objects.
 
     """
-    import os
     import random
     import shutil
 
@@ -402,7 +399,6 @@ def get_class_training_chips_data(
     :return: dictionary of ClassSimpleInfoObj objects.
 
     """
-    import os
     import random
     import shutil
 
@@ -603,8 +599,6 @@ def split_sample_train_valid_test(
                      then the output data type will be float32.
 
     """
-    import os
-
     import rsgislib.tools.filetools
     import rsgislib.tools.utils
     import rsgislib.zonalstats
@@ -689,8 +683,6 @@ def split_chip_sample_train_valid_test(
                      then the output data type will be float32.
 
     """
-    import os
-
     import rsgislib.tools.filetools
     import rsgislib.tools.utils
     import rsgislib.zonalstats
@@ -776,8 +768,6 @@ def split_chip_sample_ref_train_valid_test(
                      then the output data type will be float32.
 
     """
-    import os
-
     import rsgislib
     import rsgislib.tools.filetools
     import rsgislib.tools.utils
@@ -1147,11 +1137,8 @@ def plot_train_data(
                       otherwise call 'Var #1', 'Var #2' ... 'Var #N' etc.
 
     """
-    import os
-
     import h5py
     import numpy
-    import pandas
     import plotly.express as px
     import tqdm
 
@@ -1207,8 +1194,6 @@ def plot_train_data(
     for var_n in range(cls1_n_vars):
         df_data[var_names[var_n]] = cls_data[..., var_n]
     df_data["ClassName"] = cls_data_name
-
-    df = pandas.DataFrame(df_data)
 
     for var1 in tqdm.tqdm(var_names):
         for var2 in var_names:
@@ -1381,7 +1366,7 @@ def fill_class_timeseries(
                           for both the input and output images.
 
     """
-    from rios import applier, cuiprogress
+    from rios import applier
 
     import rsgislib.imageutils
     import rsgislib.rastergis

--- a/python/rsgislib/classification/classaccuracymetrics.py
+++ b/python/rsgislib/classification/classaccuracymetrics.py
@@ -215,7 +215,7 @@ def calc_class_accuracy_metrics(
     # normalise the confusion matrix by proportional area:
     norm_cm = cm.astype(float) / cm.sum(axis=1)[:,].reshape(-1, 1)
     norm_cm = norm_cm * prop_area
-    comp_total = norm_cm.sum(axis=1)  # same as proportional area
+
     ref_total = norm_cm.sum(axis=0)
     commission = [(row.sum() - row[idx]) for idx, row in enumerate(norm_cm)]
     omission = ref_total - numpy.diag(norm_cm)
@@ -688,7 +688,7 @@ def calc_acc_metrics_vecsamples_img(
 
     try:
         rat_cols = rsgislib.rastergis.get_rat_columns(cls_img)
-    except:
+    except Exception:
         raise rsgislib.RSGISPyException("The input image does not have a RAT...")
 
     if img_cls_name_col not in rat_cols:

--- a/python/rsgislib/classification/classcatboost.py
+++ b/python/rsgislib/classification/classcatboost.py
@@ -3,7 +3,7 @@ from typing import List, Dict
 import h5py
 import numpy
 from osgeo import gdal
-from rios import applier, cuiprogress, rat
+from rios import applier, rat
 from sklearn.metrics import accuracy_score
 
 import rsgislib

--- a/python/rsgislib/classification/classcatboost.py
+++ b/python/rsgislib/classification/classcatboost.py
@@ -18,6 +18,14 @@ try:
 except ImportError:
     HAVE_CATBOOST = False
 
+TQDM_AVAIL = True
+try:
+    import tqdm
+except ImportError:
+    import rios.cuiprogress
+
+    TQDM_AVAIL = False
+
 
 def get_catboost_mdl(mdl_file: str = None, mdl_format: str = "json"):
     """
@@ -260,12 +268,10 @@ def apply_catboost_binary_classifier(
     otherargs.out_probs = out_probs
     otherargs.img_file_info = img_file_info
 
-    try:
-        import tqdm
-
+    if TQDM_AVAIL:
         progress_bar = rsgislib.TQDMProgressBar()
-    except:
-        progress_bar = cuiprogress.GDALProgressBar()
+    else:
+        progress_bar = rios.cuiprogress.GDALProgressBar()
 
     aControls = applier.ApplierControls()
     aControls.progress = progress_bar
@@ -521,12 +527,10 @@ def apply_catboost_multiclass_classifier(
     otherargs.n_classes = n_classes
     otherargs.cls_id_lut = cls_id_lut
 
-    try:
-        import tqdm
-
+    if TQDM_AVAIL:
         progress_bar = rsgislib.TQDMProgressBar()
-    except:
-        progress_bar = cuiprogress.GDALProgressBar()
+    else:
+        progress_bar = rios.cuiprogress.GDALProgressBar()
 
     aControls = applier.ApplierControls()
     aControls.progress = progress_bar

--- a/python/rsgislib/classification/classkeraschips.py
+++ b/python/rsgislib/classification/classkeraschips.py
@@ -34,19 +34,13 @@
 ###########################################################################
 
 from __future__ import print_function
-
 import h5py
 import numpy
 import tqdm
-from osgeo import gdal
-from rios import rat
-from rios.imagereader import ImageReader
-from rios.imagewriter import ImageWriter
 
 import rsgislib
 import rsgislib.imagecalc
 import rsgislib.rastergis
-
 
 def train_keras_chips_pixel_classifier(
     cls_mdl, cls_info_dict, out_mdl_file=None, train_epochs=5, train_batch_size=32
@@ -201,6 +195,11 @@ def apply_keras_chips_pixel_classifier(
                           and a class_names (from classTrainInfo) column will be added to the output file.
 
     """
+    from osgeo import gdal
+    from rios import rat
+    from rios.imagereader import ImageReader
+    from rios.imagewriter import ImageWriter
+
     n_classes = len(class_train_info)
     cls_id_lut = numpy.zeros(n_classes)
     for clsname in class_train_info:

--- a/python/rsgislib/classification/classkeraschips.py
+++ b/python/rsgislib/classification/classkeraschips.py
@@ -42,6 +42,7 @@ import rsgislib
 import rsgislib.imagecalc
 import rsgislib.rastergis
 
+
 def train_keras_chips_pixel_classifier(
     cls_mdl, cls_info_dict, out_mdl_file=None, train_epochs=5, train_batch_size=32
 ):

--- a/python/rsgislib/classification/classkeraspxl.py
+++ b/python/rsgislib/classification/classkeraspxl.py
@@ -48,6 +48,7 @@ try:
     import tqdm
 except ImportError:
     import rios.cuiprogress
+
     TQDM_AVAIL = False
 
 

--- a/python/rsgislib/classification/classkeraspxl.py
+++ b/python/rsgislib/classification/classkeraspxl.py
@@ -43,6 +43,13 @@ from rios import applier, cuiprogress, rat
 import rsgislib
 import rsgislib.rastergis
 
+TQDM_AVAIL = True
+try:
+    import tqdm
+except ImportError:
+    import rios.cuiprogress
+    TQDM_AVAIL = False
+
 
 def train_keras_pixel_classifier(
     cls_mdl, cls_info_dict, out_mdl_file=None, train_epochs=5, train_batch_size=32
@@ -262,12 +269,10 @@ def apply_keras_pixel_classifier(
     otherargs.n_classes = n_classes
     otherargs.cls_id_lut = cls_id_lut
 
-    try:
-        import tqdm
-
+    if TQDM_AVAIL:
         progress_bar = rsgislib.TQDMProgressBar()
-    except:
-        progress_bar = cuiprogress.GDALProgressBar()
+    else:
+        progress_bar = rios.cuiprogress.GDALProgressBar()
 
     aControls = applier.ApplierControls()
     aControls.progress = progress_bar

--- a/python/rsgislib/classification/classlightgbm.py
+++ b/python/rsgislib/classification/classlightgbm.py
@@ -42,7 +42,7 @@ from typing import List, Dict
 import h5py
 import numpy
 from osgeo import gdal
-from rios import applier, cuiprogress, rat
+from rios import applier, rat
 
 import rsgislib
 import rsgislib.imagecalc

--- a/python/rsgislib/classification/classlightgbm.py
+++ b/python/rsgislib/classification/classlightgbm.py
@@ -62,6 +62,7 @@ try:
     import tqdm
 except ImportError:
     import rios.cuiprogress
+
     TQDM_AVAIL = False
 
 from sklearn.metrics import accuracy_score, roc_auc_score

--- a/python/rsgislib/classification/classlightgbm.py
+++ b/python/rsgislib/classification/classlightgbm.py
@@ -57,6 +57,13 @@ try:
 except ImportError:
     HAVE_LIGHTGBM = False
 
+TQDM_AVAIL = True
+try:
+    import tqdm
+except ImportError:
+    import rios.cuiprogress
+    TQDM_AVAIL = False
+
 from sklearn.metrics import accuracy_score, roc_auc_score
 
 warnings.filterwarnings("ignore")
@@ -1312,12 +1319,10 @@ def apply_lightgbm_binary_classifier(
     otherargs.numClassVars = num_class_vars
     otherargs.imgFileInfo = img_file_info
 
-    try:
-        import tqdm
-
+    if TQDM_AVAIL:
         progress_bar = rsgislib.TQDMProgressBar()
-    except:
-        progress_bar = cuiprogress.GDALProgressBar()
+    else:
+        progress_bar = rios.cuiprogress.GDALProgressBar()
 
     aControls = applier.ApplierControls()
     aControls.progress = progress_bar
@@ -2609,12 +2614,10 @@ def apply_lightgbm_multiclass_classifier(
     otherargs.n_classes = n_classes
     otherargs.cls_id_lut = cls_id_lut
 
-    try:
-        import tqdm
-
+    if TQDM_AVAIL:
         progress_bar = rsgislib.TQDMProgressBar()
-    except:
-        progress_bar = cuiprogress.GDALProgressBar()
+    else:
+        progress_bar = rios.cuiprogress.GDALProgressBar()
 
     aControls = applier.ApplierControls()
     aControls.progress = progress_bar

--- a/python/rsgislib/classification/classratutils.py
+++ b/python/rsgislib/classification/classratutils.py
@@ -81,7 +81,6 @@ def populate_clumps_with_class_training(
 
     uid = rsgislib.tools.utils.uid_generator(10)
 
-    classLayerSeq = list()
     tmpClassImgLayers = list()
     classNamesDict = dict()
 
@@ -199,5 +198,5 @@ def extract_rat_col_data(
         dtype=h5_dtype,
     )
     describDS = metaGrp.create_dataset("DESCRIPTION", (1,), dtype="S255")
-    describDS[0] = "Extracted from: ".format(os.path.basename(clumps_img)).encode()
+    describDS[0] = f"Extracted from: {os.path.basename(clumps_img)}".encode()
     fH5Out.close()

--- a/python/rsgislib/classification/classsklearn.py
+++ b/python/rsgislib/classification/classsklearn.py
@@ -38,7 +38,7 @@ from typing import Dict, List, Union
 import h5py
 import numpy
 from osgeo import gdal
-from rios import applier, cuiprogress, rat, ratapplier
+from rios import applier, rat, ratapplier
 from sklearn.base import BaseEstimator
 from sklearn.model_selection._search import BaseSearchCV
 
@@ -47,6 +47,13 @@ import rsgislib.imagecalc
 import rsgislib.imageutils
 import rsgislib.rastergis
 import rsgislib.classification
+
+TQDM_AVAIL = True
+try:
+    import tqdm
+except ImportError:
+    import rios.cuiprogress
+    TQDM_AVAIL = False
 
 
 def perform_sklearn_classifier_param_search(
@@ -292,12 +299,10 @@ def apply_sklearn_classifier(
     otherargs.out_score_img = out_score_img
     otherargs.cls_id_lut = cls_id_lut
 
-    try:
-        import tqdm
-
+    if TQDM_AVAIL:
         progress_bar = rsgislib.TQDMProgressBar()
-    except:
-        progress_bar = cuiprogress.GDALProgressBar()
+    else:
+        progress_bar = rios.cuiprogress.GDALProgressBar()
 
     aControls = applier.ApplierControls()
     aControls.progress = progress_bar
@@ -565,12 +570,10 @@ def apply_sklearn_classifier_rat(
     otherargs.class_colours = class_colours
     otherargs.class_train_info = cls_train_info
 
-    try:
-        import tqdm
-
+    if TQDM_AVAIL:
         progress_bar = rsgislib.TQDMProgressBar()
-    except:
-        progress_bar = cuiprogress.GDALProgressBar()
+    else:
+        progress_bar = rios.cuiprogress.GDALProgressBar()
 
     aControls = applier.ApplierControls()
     aControls.progress = progress_bar

--- a/python/rsgislib/classification/classsklearn.py
+++ b/python/rsgislib/classification/classsklearn.py
@@ -53,6 +53,7 @@ try:
     import tqdm
 except ImportError:
     import rios.cuiprogress
+
     TQDM_AVAIL = False
 
 

--- a/python/rsgislib/classification/classxgboost.py
+++ b/python/rsgislib/classification/classxgboost.py
@@ -42,6 +42,7 @@ import h5py
 import numpy
 from osgeo import gdal
 from rios import applier, rat
+from sklearn.metrics import accuracy_score, roc_auc_score
 
 import rsgislib
 import rsgislib.classification
@@ -63,8 +64,6 @@ except ImportError:
     import rios.cuiprogress
 
     TQDM_AVAIL = False
-
-from sklearn.metrics import accuracy_score, roc_auc_score
 
 
 def optimise_xgboost_binary_classifier(

--- a/python/rsgislib/classification/classxgboost.py
+++ b/python/rsgislib/classification/classxgboost.py
@@ -41,7 +41,7 @@ from typing import Dict, List, Union
 import h5py
 import numpy
 from osgeo import gdal
-from rios import applier, cuiprogress, rat
+from rios import applier, rat
 
 import rsgislib
 import rsgislib.classification
@@ -55,6 +55,13 @@ try:
     import xgboost as xgb
 except ImportError:
     HAVE_XGBOOST = False
+
+TQDM_AVAIL = True
+try:
+    import tqdm
+except ImportError:
+    import rios.cuiprogress
+    TQDM_AVAIL = False
 
 from sklearn.metrics import accuracy_score, roc_auc_score
 
@@ -1005,12 +1012,10 @@ def apply_xgboost_binary_classifier(
     otherargs.numClassVars = num_class_vars
     otherargs.imgFileInfo = img_file_info
 
-    try:
-        import tqdm
-
+    if TQDM_AVAIL:
         progress_bar = rsgislib.TQDMProgressBar()
-    except:
-        progress_bar = cuiprogress.GDALProgressBar()
+    else:
+        progress_bar = rios.cuiprogress.GDALProgressBar()
 
     aControls = applier.ApplierControls()
     aControls.progress = progress_bar
@@ -2038,12 +2043,10 @@ def apply_xgboost_multiclass_classifier(
     otherargs.n_classes = n_classes
     otherargs.cls_id_lut = cls_id_lut
 
-    try:
-        import tqdm
-
+    if TQDM_AVAIL:
         progress_bar = rsgislib.TQDMProgressBar()
-    except:
-        progress_bar = cuiprogress.GDALProgressBar()
+    else:
+        progress_bar = rios.cuiprogress.GDALProgressBar()
 
     aControls = applier.ApplierControls()
     aControls.progress = progress_bar
@@ -2236,12 +2239,10 @@ def apply_xgboost_multiclass_classifier_rat(
     otherargs.class_colours = class_colours
     otherargs.cls_info_dict = cls_info_dict
 
-    try:
-        import tqdm
-
+    if TQDM_AVAIL:
         progress_bar = rsgislib.TQDMProgressBar()
-    except:
-        progress_bar = cuiprogress.GDALProgressBar()
+    else:
+        progress_bar = rios.cuiprogress.GDALProgressBar()
 
     aControls = ratapplier.RatApplierControls()
     aControls.progress = progress_bar

--- a/python/rsgislib/classification/classxgboost.py
+++ b/python/rsgislib/classification/classxgboost.py
@@ -61,6 +61,7 @@ try:
     import tqdm
 except ImportError:
     import rios.cuiprogress
+
     TQDM_AVAIL = False
 
 from sklearn.metrics import accuracy_score, roc_auc_score

--- a/python/rsgislib/dataaccess/usgs_m2m.py
+++ b/python/rsgislib/dataaccess/usgs_m2m.py
@@ -257,7 +257,7 @@ def get_earth_explorer_datasets(api_key: str) -> Dict[str, List[str]]:
         dataset_names[dataset_info[dataset_id]["categoryName"]] = list()
         if "subCategories" in dataset_info[dataset_id]:
             for sub_cat_id in dataset_info[dataset_id]["subCategories"]:
-                if type(sub_cat_id) != dict:
+                if not isinstance(sub_cat_id, dict):
                     for dataset_item in dataset_info[dataset_id]["subCategories"][
                         sub_cat_id
                     ]["datasets"]:

--- a/python/rsgislib/droneutils/__init__.py
+++ b/python/rsgislib/droneutils/__init__.py
@@ -146,7 +146,7 @@ def split_photos_by_time(
                     data = data.decode()
                 if tag == date_time_tag:
                     img_dt_lut[img_file] = data
-            except:
+            except Exception:
                 continue
 
     img_clusters = list()

--- a/python/rsgislib/elevation/__init__.py
+++ b/python/rsgislib/elevation/__init__.py
@@ -75,9 +75,9 @@ def fft_dem_fusion(
 
     rows, cols = srcbandLowResArr.shape
     crow, ccol = int(rows / 2), int(cols / 2)
-    fshiftLowRes[
-        crow - c_size : crow + c_size, ccol - c_size : ccol + c_size
-    ] = fshiftHighRes[crow - c_size : crow + c_size, ccol - c_size : ccol + c_size]
+    fshiftLowRes[crow - c_size : crow + c_size, ccol - c_size : ccol + c_size] = (
+        fshiftHighRes[crow - c_size : crow + c_size, ccol - c_size : ccol + c_size]
+    )
     f_ishift = numpy.fft.ifftshift(fshiftLowRes)
     img_back = numpy.fft.ifft2(f_ishift)
     img_back = numpy.abs(img_back)

--- a/python/rsgislib/elevation/__init__.py
+++ b/python/rsgislib/elevation/__init__.py
@@ -67,11 +67,11 @@ def fft_dem_fusion(
 
     fftHighRes = numpy.fft.fft2(srcbandHighResArr)
     fshiftHighRes = numpy.fft.fftshift(fftHighRes)
-    magSpectHighRes = 20 * numpy.log(numpy.abs(fshiftHighRes))
+    # magSpectHighRes = 20 * numpy.log(numpy.abs(fshiftHighRes))
 
     fftLowRes = numpy.fft.fft2(srcbandLowResArr)
     fshiftLowRes = numpy.fft.fftshift(fftLowRes)
-    magSpectLowRes = 20 * numpy.log(numpy.abs(fshiftLowRes))
+    # magSpectLowRes = 20 * numpy.log(numpy.abs(fshiftLowRes))
 
     rows, cols = srcbandLowResArr.shape
     crow, ccol = int(rows / 2), int(cols / 2)

--- a/python/rsgislib/imagecalc/__init__.py
+++ b/python/rsgislib/imagecalc/__init__.py
@@ -557,7 +557,7 @@ def count_pxls_of_val(input_img: str, vals: List[int], img_band: int = None):
         This is an internal rios function
         """
         for idx in range(otherargs.num_vals):
-            if img_band is None:
+            if otherargs.img_band_idx is None:
                 otherargs.out_vals[idx] = (
                     otherargs.out_vals[idx]
                     + (inputs.image == otherargs.vals[idx]).sum()
@@ -565,7 +565,9 @@ def count_pxls_of_val(input_img: str, vals: List[int], img_band: int = None):
             else:
                 otherargs.out_vals[idx] = (
                     otherargs.out_vals[idx]
-                    + (inputs.image[img_band_idx,] == otherargs.vals[idx]).sum()
+                    + (
+                        inputs.image[otherargs.img_band_idx,] == otherargs.vals[idx]
+                    ).sum()
                 )
 
     if img_band is not None:

--- a/python/rsgislib/imagecalc/__init__.py
+++ b/python/rsgislib/imagecalc/__init__.py
@@ -3,6 +3,10 @@
 The imagecalc module contains functions for performing a number of
 calculating on images.
 """
+# import the C++ extension into this level
+from ._imagecalc import *
+
+import rsgislib
 
 import math
 import os
@@ -19,10 +23,6 @@ except ImportError:
 
     TQDM_AVAIL = False
 
-import rsgislib
-
-# import the C++ extension into this level
-from ._imagecalc import *
 
 gdal.UseExceptions()
 
@@ -2665,7 +2665,7 @@ def normalise_img_pxl_vals_py(
 
     elif norm_type == rsgislib.IMG_STRETCH_USER:
         if n_bands == 1:
-            if type(stch_min_max_vals) is list:
+            if isinstance(stch_min_max_vals, list):
                 if len(stch_min_max_vals) != 1:
                     raise rsgislib.RSGISPyException(
                         "The input image has 1 band and therefore stch_min_max_vals "
@@ -2675,7 +2675,7 @@ def normalise_img_pxl_vals_py(
                 else:
                     stch_min_max_vals = stch_min_max_vals[0]
 
-            if type(stch_min_max_vals) is not dict:
+            if not isinstance(stch_min_max_vals, dict):
                 raise rsgislib.RSGISPyException(
                     "The input image has 1 band and therefore stch_min_max_vals "
                     "variable must be a dict or list of length 1 with "
@@ -2689,7 +2689,7 @@ def normalise_img_pxl_vals_py(
 
             stch_min_max_vals = [stch_min_max_vals]
         else:
-            if type(stch_min_max_vals) is not list:
+            if not isinstance(stch_min_max_vals, list):
                 raise rsgislib.RSGISPyException(
                     "There are more than 1 band and therefore "
                     "stch_min_max_vals variable must be a list."

--- a/python/rsgislib/imagecalc/calc_pt_win_smpls.py
+++ b/python/rsgislib/imagecalc/calc_pt_win_smpls.py
@@ -290,7 +290,6 @@ def calc_pt_smpl_img_vals(
 
 
 class RSGISDebugExportImg(RSGISCalcSumVals):
-
     """
     Debug class which exports the data to an out image.
     """

--- a/python/rsgislib/imagecalc/calcindices.py
+++ b/python/rsgislib/imagecalc/calcindices.py
@@ -665,11 +665,13 @@ def calc_evi(
                          0-1 (Default: 1000 to match rsgislib/arcsi)
 
     """
-    expression = f"( (nir/{scale_factor}) + ({c1} * (red/{scale_factor})) - " \
-                 f"({c2} * (blue/{scale_factor})) + {l} ) !=0? " \
-                 f"{g}*( ( (nir/{scale_factor})-(red/{scale_factor}) ) / " \
-                 f"( (nir/{scale_factor}) + ({c1} * (red/{scale_factor})) - " \
-                 f"({c2} * (blue/{scale_factor})) + {l} ) ):-999"
+    expression = (
+        f"( (nir/{scale_factor}) + ({c1} * (red/{scale_factor})) - "
+        f"({c2} * (blue/{scale_factor})) + {l} ) !=0? "
+        f"{g}*( ( (nir/{scale_factor})-(red/{scale_factor}) ) / "
+        f"( (nir/{scale_factor}) + ({c1} * (red/{scale_factor})) - "
+        f"({c2} * (blue/{scale_factor})) + {l} ) ):-999"
+    )
 
     band_defns = []
     band_defns.append(rsgislib.imagecalc.BandDefn("blue", input_img, img_blue_band))
@@ -719,9 +721,11 @@ def calc_evi2(
                          0-1 (Default: 1000 to match rsgislib/arcsi)
 
     """
-    expression = f"((nir/{scale_factor})+({c}*(red/{scale_factor}))+{l})!=0?" \
-                 f"{g}*( (nir/{scale_factor})-(red/{scale_factor})) / " \
-                 f"((nir/{scale_factor})+ ({c}*(red/{scale_factor}))+{l}):-999"
+    expression = (
+        f"((nir/{scale_factor})+({c}*(red/{scale_factor}))+{l})!=0?"
+        f"{g}*( (nir/{scale_factor})-(red/{scale_factor})) / "
+        f"((nir/{scale_factor})+ ({c}*(red/{scale_factor}))+{l}):-999"
+    )
 
     band_defns = []
     band_defns.append(rsgislib.imagecalc.BandDefn("red", input_img, img_red_band))
@@ -907,9 +911,11 @@ def calc_si(
                          0-1 (Default: 1000 to match rsgislib/arcsi)
 
     """
-    expression = f"(red==0)||(green==0)||(blue==0)?-999:" \
-                 f"( (1-(blue/{scale_factor})) * (1-(green/{scale_factor})) " \
-                 f"* (1-(red/{scale_factor})))^(1/3)"
+    expression = (
+        f"(red==0)||(green==0)||(blue==0)?-999:"
+        f"( (1-(blue/{scale_factor})) * (1-(green/{scale_factor})) "
+        f"* (1-(red/{scale_factor})))^(1/3)"
+    )
     band_defns = []
     band_defns.append(rsgislib.imagecalc.BandDefn("blue", input_img, img_blue_band))
     band_defns.append(rsgislib.imagecalc.BandDefn("green", input_img, img_green_band))
@@ -1115,9 +1121,11 @@ def calc_ndbsi(
     )
 
     # Calc r
-    expression = f"(red==0)||(nir==0)||(swir==0)?-999:" \
-                 f"1-( ( (swir/{scale_factor}) - (nir/{scale_factor}) ) / " \
-                 f"( 3 * abs( (nir/{scale_factor}) - (red/{scale_factor}) ) ) )"
+    expression = (
+        f"(red==0)||(nir==0)||(swir==0)?-999:"
+        f"1-( ( (swir/{scale_factor}) - (nir/{scale_factor}) ) / "
+        f"( 3 * abs( (nir/{scale_factor}) - (red/{scale_factor}) ) ) )"
+    )
     band_defns = []
     band_defns.append(rsgislib.imagecalc.BandDefn("red", input_img, img_red_band))
     band_defns.append(rsgislib.imagecalc.BandDefn("nir", input_img, img_nir_band))
@@ -1135,10 +1143,12 @@ def calc_ndbsi(
         tmp_k_img, expression, gdalformat, rsgislib.TYPE_32FLOAT, band_defns
     )
 
-    expression = f"k==-999?-999:k<0?abs((swir/{scale_factor})-(blue/{scale_factor})) " \
-                 f"/ ((swir/{scale_factor})+(blue/{scale_factor}))*(-1):" \
-                 f"((swir/{scale_factor})-(blue/{scale_factor})) / " \
-                 f"((swir/{scale_factor})+(blue/{scale_factor}))"
+    expression = (
+        f"k==-999?-999:k<0?abs((swir/{scale_factor})-(blue/{scale_factor})) "
+        f"/ ((swir/{scale_factor})+(blue/{scale_factor}))*(-1):"
+        f"((swir/{scale_factor})-(blue/{scale_factor})) / "
+        f"((swir/{scale_factor})+(blue/{scale_factor}))"
+    )
     band_defns = []
     band_defns.append(rsgislib.imagecalc.BandDefn("swir", input_img, img_swir_band))
     band_defns.append(rsgislib.imagecalc.BandDefn("blue", input_img, img_blue_band))

--- a/python/rsgislib/imagecalc/specunmixing/__init__.py
+++ b/python/rsgislib/imagecalc/specunmixing/__init__.py
@@ -33,9 +33,17 @@
 ############################################################################
 
 import os
-
+import rsgislib
 import numpy
 from osgeo import gdal
+
+TQDM_AVAIL = True
+try:
+    import tqdm
+except ImportError:
+    import rios.cuiprogress
+
+    TQDM_AVAIL = False
 
 import rsgislib
 
@@ -290,12 +298,10 @@ def spec_unmix_spts_ucls(
 
     import rsgislib.imageutils
 
-    try:
+    if TQDM_AVAIL:
         progress_bar = rsgislib.TQDMProgressBar()
-    except:
-        from rios import cuiprogress
-
-        progress_bar = cuiprogress.GDALProgressBar()
+    else:
+        progress_bar = rios.cuiprogress.GDALProgressBar()
 
     m, n, endmembers_arr = read_endmembers_mtxt(endmembers_file, gain, weight)
 
@@ -411,12 +417,10 @@ def spec_unmix_spts_nnls(
 
     import rsgislib.imageutils
 
-    try:
+    if TQDM_AVAIL:
         progress_bar = rsgislib.TQDMProgressBar()
-    except:
-        from rios import cuiprogress
-
-        progress_bar = cuiprogress.GDALProgressBar()
+    else:
+        progress_bar = rios.cuiprogress.GDALProgressBar()
 
     m, n, endmembers_arr = read_endmembers_mtxt(endmembers_file, gain, weight)
 
@@ -521,12 +525,10 @@ def spec_unmix_spts_fcls(
 
     import rsgislib.imageutils
 
-    try:
+    if TQDM_AVAIL:
         progress_bar = rsgislib.TQDMProgressBar()
-    except:
-        from rios import cuiprogress
-
-        progress_bar = cuiprogress.GDALProgressBar()
+    else:
+        progress_bar = rios.cuiprogress.GDALProgressBar()
 
     m, n, endmembers_arr = read_endmembers_mtxt(endmembers_file, gain)
 
@@ -638,12 +640,10 @@ def spec_unmix_pymcr_nnls(
 
     import rsgislib.imageutils
 
-    try:
+    if TQDM_AVAIL:
         progress_bar = rsgislib.TQDMProgressBar()
-    except:
-        from rios import cuiprogress
-
-        progress_bar = cuiprogress.GDALProgressBar()
+    else:
+        progress_bar = rios.cuiprogress.GDALProgressBar()
 
     m, n, endmembers_arr = read_endmembers_mtxt(endmembers_file, gain, weight)
 
@@ -754,12 +754,10 @@ def spec_unmix_pymcr_fcls(
 
     import rsgislib.imageutils
 
-    try:
+    if TQDM_AVAIL:
         progress_bar = rsgislib.TQDMProgressBar()
-    except:
-        from rios import cuiprogress
-
-        progress_bar = cuiprogress.GDALProgressBar()
+    else:
+        progress_bar = rios.cuiprogress.GDALProgressBar()
 
     m, n, endmembers_arr = read_endmembers_mtxt(endmembers_file, gain)
 
@@ -844,12 +842,10 @@ def rescale_unmixing_results(input_img, output_img, gdalformat="KEA", calc_stats
     """
     from rios import applier
 
-    try:
+    if TQDM_AVAIL:
         progress_bar = rsgislib.TQDMProgressBar()
-    except:
-        from rios import cuiprogress
-
-        progress_bar = cuiprogress.GDALProgressBar()
+    else:
+        progress_bar = rios.cuiprogress.GDALProgressBar()
 
     infiles = applier.FilenameAssociations()
     infiles.image = input_img
@@ -904,12 +900,10 @@ def predict_refl_linear_unmixing(
     """
     from rios import applier
 
-    try:
+    if TQDM_AVAIL:
         progress_bar = rsgislib.TQDMProgressBar()
-    except:
-        from rios import cuiprogress
-
-        progress_bar = cuiprogress.GDALProgressBar()
+    else:
+        progress_bar = rios.cuiprogress.GDALProgressBar()
     endmembers_info = read_endmembers_mtxt(endmembers_file)
 
     infiles = applier.FilenameAssociations()
@@ -992,12 +986,10 @@ def calc_unmixing_rmse_residual_err(
     """
     from rios import applier
 
-    try:
+    if TQDM_AVAIL:
         progress_bar = rsgislib.TQDMProgressBar()
-    except:
-        from rios import cuiprogress
-
-        progress_bar = cuiprogress.GDALProgressBar()
+    else:
+        progress_bar = rios.cuiprogress.GDALProgressBar()
 
     endmembers_info = read_endmembers_mtxt(endmembers_file)
 

--- a/python/rsgislib/imagecalc/specunmixing/__init__.py
+++ b/python/rsgislib/imagecalc/specunmixing/__init__.py
@@ -33,7 +33,6 @@
 ############################################################################
 
 import os
-import rsgislib
 import numpy
 from osgeo import gdal
 
@@ -841,6 +840,7 @@ def rescale_unmixing_results(input_img, output_img, gdalformat="KEA", calc_stats
 
     """
     from rios import applier
+    import rsgislib.imageutils
 
     if TQDM_AVAIL:
         progress_bar = rsgislib.TQDMProgressBar()
@@ -875,8 +875,6 @@ def rescale_unmixing_results(input_img, output_img, gdalformat="KEA", calc_stats
     applier.apply(_applyUnmixRescale, infiles, outfiles, otherargs, controls=aControls)
 
     if calc_stats:
-        import rsgislib.imageutils
-
         rsgislib.imageutils.pop_img_stats(
             output_img, use_no_data=True, no_data_val=0, calc_pyramids=True
         )
@@ -899,6 +897,7 @@ def predict_refl_linear_unmixing(
 
     """
     from rios import applier
+    import rsgislib.imageutils
 
     if TQDM_AVAIL:
         progress_bar = rsgislib.TQDMProgressBar()
@@ -947,8 +946,6 @@ def predict_refl_linear_unmixing(
     applier.apply(_predict_refl_img, infiles, outfiles, otherargs, controls=aControls)
 
     if calc_stats:
-        import rsgislib.imageutils
-
         rsgislib.imageutils.pop_img_stats(
             output_img, use_no_data=True, no_data_val=0, calc_pyramids=True
         )
@@ -985,6 +982,7 @@ def calc_unmixing_rmse_residual_err(
 
     """
     from rios import applier
+    import rsgislib.imageutils
 
     if TQDM_AVAIL:
         progress_bar = rsgislib.TQDMProgressBar()
@@ -1070,8 +1068,6 @@ def calc_unmixing_rmse_residual_err(
     )
 
     if calc_stats:
-        import rsgislib.imageutils
-
         rsgislib.imageutils.set_band_names(
             output_img, ["RMSE", "RMSPE", "Residual"], feedback=False
         )

--- a/python/rsgislib/imagecalibration/sensorlvl2data.py
+++ b/python/rsgislib/imagecalibration/sensorlvl2data.py
@@ -40,6 +40,14 @@ import numpy
 import rsgislib
 import rsgislib.tools.sensors
 
+TQDM_AVAIL = True
+try:
+    import tqdm
+except ImportError:
+    import rios.cuiprogress
+
+    TQDM_AVAIL = False
+
 
 def create_stacked_sref_ls_oli_cl2_lv2_img(
     input_file: str,
@@ -640,12 +648,10 @@ def parse_landsat_c2_qa_pixel_img(
         else:
             qa_lut[val]["CirrusConfidence"] = 1
 
-    try:
+    if TQDM_AVAIL:
         progress_bar = rsgislib.TQDMProgressBar()
-    except:
-        from rios import cuiprogress
-
-        progress_bar = cuiprogress.GDALProgressBar()
+    else:
+        progress_bar = rios.cuiprogress.GDALProgressBar()
 
     infiles = applier.FilenameAssociations()
     infiles.image = input_img

--- a/python/rsgislib/imagecalibration/solarangles.py
+++ b/python/rsgislib/imagecalibration/solarangles.py
@@ -33,8 +33,17 @@
 #
 ############################################################################
 
+import rsgislib
 import numpy
 from osgeo import osr
+
+TQDM_AVAIL = True
+try:
+    import tqdm
+except ImportError:
+    import rios.cuiprogress
+
+    TQDM_AVAIL = False
 
 
 def get_solar_irr_convention_solar_azimuth_from_usgs(solarAz):
@@ -97,16 +106,12 @@ def calc_solar_azimuth_zenith(inputImg, inImgDateTime, outputImg, gdalformat):
     :param gdalformat: output file format (e.g., KEA)
     """
     import Pysolar
-    from rios import applier, cuiprogress
+    from rios import applier
 
-    import rsgislib
-
-    try:
-        import tqdm
-
+    if TQDM_AVAIL:
         progress_bar = rsgislib.TQDMProgressBar()
-    except:
-        progress_bar = cuiprogress.GDALProgressBar()
+    else:
+        progress_bar = rios.cuiprogress.GDALProgressBar()
 
     infiles = applier.FilenameAssociations()
     infiles.image1 = inputImg

--- a/python/rsgislib/imageutils/__init__.py
+++ b/python/rsgislib/imageutils/__init__.py
@@ -19,6 +19,7 @@ try:
     import tqdm
 except ImportError:
     import rios.cuiprogress
+
     TQDM_AVAIL = False
 
 # import the C++ extension into this level
@@ -220,9 +221,9 @@ def set_env_vars_deflate_gtiff_outs(bigtiff: bool = False):
 
     """
     if bigtiff:
-        os.environ[
-            "RSGISLIB_IMG_CRT_OPTS_GTIFF"
-        ] = "TILED=YES:COMPRESS=DEFLATE:BIGTIFF=YES"
+        os.environ["RSGISLIB_IMG_CRT_OPTS_GTIFF"] = (
+            "TILED=YES:COMPRESS=DEFLATE:BIGTIFF=YES"
+        )
     else:
         os.environ["RSGISLIB_IMG_CRT_OPTS_GTIFF"] = "TILED=YES:COMPRESS=DEFLATE"
 
@@ -3030,7 +3031,9 @@ def extract_img_pxl_sample(
         img_bands_trans = numpy.transpose(img_bands)
 
         if otherargs.no_data_val is not None:
-            img_bands_trans = img_bands_trans[(img_bands_trans != otherargs.no_data_val).all(axis=1)]
+            img_bands_trans = img_bands_trans[
+                (img_bands_trans != otherargs.no_data_val).all(axis=1)
+            ]
 
         if img_bands_trans.shape[0] > 0:
             n_samp = int((img_bands_trans.shape[0]) / otherargs.pxl_n_sample)
@@ -3040,13 +3043,14 @@ def extract_img_pxl_sample(
             if otherargs.out_arr is None:
                 otherargs.out_arr = img_bands_trans_smpl
             else:
-                otherargs.out_arr = numpy.concatenate((otherargs.out_arr, img_bands_trans_smpl), axis=0)
+                otherargs.out_arr = numpy.concatenate(
+                    (otherargs.out_arr, img_bands_trans_smpl), axis=0
+                )
 
     if TQDM_AVAIL:
         progress_bar = rsgislib.TQDMProgressBar()
     else:
         progress_bar = rios.cuiprogress.GDALProgressBar()
-
 
     infiles = applier.FilenameAssociations()
     infiles.image = input_img
@@ -3097,7 +3101,9 @@ def extract_img_pxl_vals_in_msk(
             if (band > 0) and (band <= img_bands.shape[0]):
                 img_band_lst.append(img_bands[band - 1])
             else:
-                raise rsgislib.RSGISPyException(f"Band ({band}) specified is not within the image")
+                raise rsgislib.RSGISPyException(
+                    f"Band ({band}) specified is not within the image"
+                )
         img_bands_sel = numpy.stack(img_band_lst, axis=0)
         img_bands_trans = numpy.transpose(img_bands_sel)
 
@@ -3106,19 +3112,22 @@ def extract_img_pxl_vals_in_msk(
 
         # If no data provided mask to valid values.
         if otherargs.no_data_val is not None:
-            img_bands_trans = img_bands_trans[(img_bands_trans != otherargs.no_data_val).all(axis=1)]
+            img_bands_trans = img_bands_trans[
+                (img_bands_trans != otherargs.no_data_val).all(axis=1)
+            ]
 
         if img_bands_trans.shape[0] > 0:
             if otherargs.out_arr is None:
                 otherargs.out_arr = img_bands_trans
             else:
-                otherargs.out_arr = numpy.concatenate((otherargs.out_arr, img_bands_trans), axis=0)
+                otherargs.out_arr = numpy.concatenate(
+                    (otherargs.out_arr, img_bands_trans), axis=0
+                )
 
     if TQDM_AVAIL:
         progress_bar = rsgislib.TQDMProgressBar()
     else:
         progress_bar = rios.cuiprogress.GDALProgressBar()
-
 
     infiles = applier.FilenameAssociations()
     infiles.image = input_img
@@ -4782,9 +4791,9 @@ def polyfill_nan_data_values(
                         if otherargs.mean_abs_diff is not None:
                             pxl_mean = numpy.nanmean(img_flat[pxl_idx])
                             pred_vals_diff = numpy.abs(pred_vals - pxl_mean)
-                            pred_vals[
-                                pred_vals_diff > otherargs.mean_abs_diff
-                            ] = pxl_mean
+                            pred_vals[pred_vals_diff > otherargs.mean_abs_diff] = (
+                                pxl_mean
+                            )
                         repl_idxs = numpy.arange(0, pred_vals.shape[0])[
                             numpy.invert(finite_msk)
                         ]

--- a/python/rsgislib/imageutils/__init__.py
+++ b/python/rsgislib/imageutils/__init__.py
@@ -2,11 +2,13 @@
 """
 The imageutils module contains general utilities for applying to images.
 """
+# import the C++ extension into this level
+from ._imageutils import *
 
 import math
 import os
 import shutil
-from typing import Dict, List, Union
+from typing import Dict, List
 
 import numpy
 from osgeo import gdal, osr
@@ -21,9 +23,6 @@ except ImportError:
     import rios.cuiprogress
 
     TQDM_AVAIL = False
-
-# import the C++ extension into this level
-from ._imageutils import *
 
 gdal.UseExceptions()
 
@@ -1276,7 +1275,6 @@ def get_utm_zone(input_img: str):
     spatRef.ImportFromWkt(projStr)
     utmZone = None
     if spatRef.IsProjected():
-        projName = spatRef.GetAttrValue("projcs")
         zone = spatRef.GetUTMZone()
         if zone != 0:
             if zone < 0:
@@ -1342,7 +1340,7 @@ def set_band_names(input_img: str, band_names: list, feedback: bool = False):
 
         imgBand = dataset.GetRasterBand(band)
         # Check the image band is available
-        if not imgBand is None:
+        if imgBand is not None:
             if feedback:
                 print('Setting Band {0} to "{1}"'.format(band, bandName))
             imgBand.SetDescription(bandName)
@@ -1371,7 +1369,7 @@ def get_band_names(input_img: str):
     for i in range(dataset.RasterCount):
         imgBand = dataset.GetRasterBand(i + 1)
         # Check the image band is available
-        if not imgBand is None:
+        if imgBand is not None:
             bandNames.append(imgBand.GetDescription())
         else:
             raise rsgislib.RSGISPyException(
@@ -2259,7 +2257,7 @@ def resample_img_to_match(
 
     backVal = 0.0
     haveNoData = False
-    if no_data_val != None:
+    if no_data_val is not None:
         backVal = float(no_data_val)
         haveNoData = True
 
@@ -4271,7 +4269,6 @@ def whiten_image(
             raise rsgislib.RSGISPyException(
                 "Could not open image band ({})".format(n + 1)
             )
-        no_data_val = img_band.GetNoDataValue()
         band_arr = img_band.ReadAsArray().flatten()
         band_arr = band_arr.astype(numpy.float32)
         img_data[n] = band_arr

--- a/python/rsgislib/imageutils/__init__.py
+++ b/python/rsgislib/imageutils/__init__.py
@@ -14,6 +14,13 @@ from rios import applier
 
 import rsgislib
 
+TQDM_AVAIL = True
+try:
+    import tqdm
+except ImportError:
+    import rios.cuiprogress
+    TQDM_AVAIL = False
+
 # import the C++ extension into this level
 from ._imageutils import *
 
@@ -2748,14 +2755,10 @@ def calc_pixel_locations(input_img: str, output_img: str, gdalformat: str):
     :param gdalformat: the GDAL image file format of the output image file.
 
     """
-    try:
-        import tqdm
-
+    if TQDM_AVAIL:
         progress_bar = rsgislib.TQDMProgressBar()
-    except:
-        from rios import cuiprogress
-
-        progress_bar = cuiprogress.GDALProgressBar()
+    else:
+        progress_bar = rios.cuiprogress.GDALProgressBar()
 
     infiles = applier.FilenameAssociations()
     infiles.image1 = input_img
@@ -2795,12 +2798,10 @@ def calc_wgs84_pixel_area(
 
     import rsgislib.tools.projection
 
-    try:
+    if TQDM_AVAIL:
         progress_bar = rsgislib.TQDMProgressBar()
-    except:
-        from rios import cuiprogress
-
-        progress_bar = cuiprogress.GDALProgressBar()
+    else:
+        progress_bar = rios.cuiprogress.GDALProgressBar()
 
     x_res, y_res = get_img_res(input_img, abs_vals=True)
 
@@ -2972,14 +2973,10 @@ def generate_random_pxl_vals_img(
     :param up_val: upper value
 
     """
-    try:
-        import tqdm
-
+    if TQDM_AVAIL:
         progress_bar = rsgislib.TQDMProgressBar()
-    except:
-        from rios import cuiprogress
-
-        progress_bar = cuiprogress.GDALProgressBar()
+    else:
+        progress_bar = rios.cuiprogress.GDALProgressBar()
 
     infiles = applier.FilenameAssociations()
     infiles.inImg = input_img
@@ -3130,14 +3127,10 @@ def combine_binary_masks(
     import rsgislib.imagecalc
     import rsgislib.tools.utils
 
-    try:
-        import tqdm
-
+    if TQDM_AVAIL:
         progress_bar = rsgislib.TQDMProgressBar()
-    except:
-        from rios import cuiprogress
-
-        progress_bar = cuiprogress.GDALProgressBar()
+    else:
+        progress_bar = rios.cuiprogress.GDALProgressBar()
 
     in_vals_dict = dict()
     msk_imgs = list()
@@ -4309,14 +4302,10 @@ def spectral_smoothing(
     import scipy.signal
     from rios import applier
 
-    try:
-        import tqdm
-
+    if TQDM_AVAIL:
         progress_bar = rsgislib.TQDMProgressBar()
-    except:
-        from rios import cuiprogress
-
-        progress_bar = cuiprogress.GDALProgressBar()
+    else:
+        progress_bar = rios.cuiprogress.GDALProgressBar()
 
     np_dtype = rsgislib.get_numpy_datatype(datatype)
     in_no_date = get_img_no_data_value(input_img)
@@ -4398,14 +4387,10 @@ def calc_wsg84_pixel_size(input_img: str, output_img: str, gdalformat: str = "KE
 
     import rsgislib.tools.projection
 
-    try:
-        import tqdm
-
+    if TQDM_AVAIL:
         progress_bar = rsgislib.TQDMProgressBar()
-    except:
-        from rios import cuiprogress
-
-        progress_bar = cuiprogress.GDALProgressBar()
+    else:
+        progress_bar = rios.cuiprogress.GDALProgressBar()
 
     x_res, y_res = get_img_res(input_img, abs_vals=True)
 
@@ -4463,14 +4448,10 @@ def mask_all_band_zero_vals(
     """
     from rios import applier
 
-    try:
-        import tqdm
-
+    if TQDM_AVAIL:
         progress_bar = rsgislib.TQDMProgressBar()
-    except:
-        from rios import cuiprogress
-
-        progress_bar = cuiprogress.GDALProgressBar()
+    else:
+        progress_bar = rios.cuiprogress.GDALProgressBar()
 
     infiles = applier.FilenameAssociations()
     infiles.image = input_img
@@ -4611,14 +4592,10 @@ def mask_outliners_data_values(
     """
     from rios import applier
 
-    try:
-        import tqdm
-
+    if TQDM_AVAIL:
         progress_bar = rsgislib.TQDMProgressBar()
-    except:
-        from rios import cuiprogress
-
-        progress_bar = cuiprogress.GDALProgressBar()
+    else:
+        progress_bar = rios.cuiprogress.GDALProgressBar()
 
     np_dtype = rsgislib.get_numpy_datatype(rsgislib.TYPE_32FLOAT)
     in_no_date = get_img_no_data_value(input_img)
@@ -4720,14 +4697,10 @@ def polyfill_nan_data_values(
     """
     from rios import applier
 
-    try:
-        import tqdm
-
+    if TQDM_AVAIL:
         progress_bar = rsgislib.TQDMProgressBar()
-    except:
-        from rios import cuiprogress
-
-        progress_bar = cuiprogress.GDALProgressBar()
+    else:
+        progress_bar = rios.cuiprogress.GDALProgressBar()
 
     np_dtype = rsgislib.get_numpy_datatype(rsgislib.TYPE_32FLOAT)
     in_no_date = get_img_no_data_value(input_img)

--- a/python/rsgislib/imageutils/imagecomp.py
+++ b/python/rsgislib/imageutils/imagecomp.py
@@ -373,7 +373,6 @@ def create_max_ndvi_ndwi_composite(
             img_lyrs = numpy.empty(num_in_lyrs + 1, dtype=numpy.dtype("a255"))
 
             # Generate Comp Ref layers:
-            land_water_msk_band_defns = []
             msk_imgs = []
             idx = 1
             for img in in_images_sub_to_ref:

--- a/python/rsgislib/imageutils/imagelut.py
+++ b/python/rsgislib/imageutils/imagelut.py
@@ -41,10 +41,10 @@ from typing import List
 
 from osgeo import gdal, ogr
 
-gdal.UseExceptions()
-
 import rsgislib
 import rsgislib.vectorutils
+
+gdal.UseExceptions()
 
 
 def create_img_extent_lut(

--- a/python/rsgislib/imageutils/stdimgblockiter.py
+++ b/python/rsgislib/imageutils/stdimgblockiter.py
@@ -12,7 +12,6 @@ import rsgislib.tools.projection
 
 
 class StdImgBlockIter:
-
     """
     A class to read and write images in blocks where all blocks are all identical in
     size. To deal with image boundaries, where block do not divide into the the image
@@ -137,9 +136,9 @@ class StdImgBlockIter:
             self.img_info[img.name]["pxl_size"] = rsgislib.imageutils.get_img_size(
                 img.file_name
             )
-            self.img_info[img.name][
-                "epsg"
-            ] = rsgislib.imageutils.get_epsg_proj_from_img(img.file_name)
+            self.img_info[img.name]["epsg"] = (
+                rsgislib.imageutils.get_epsg_proj_from_img(img.file_name)
+            )
             if self.img_info[img.name]["epsg"] is None:
                 raise rsgislib.RSGISPyException(
                     "The input image ({}) does not have a "

--- a/python/rsgislib/imageutils/stdimgblockiterbatches.py
+++ b/python/rsgislib/imageutils/stdimgblockiterbatches.py
@@ -12,7 +12,6 @@ import rsgislib.tools.projection
 
 
 class StdImgBlockIterBatches:
-
     """
     A class to read and write images in blocks where all blocks are all identical in
     size. To deal with image boundaries, where block do not divide into the the image
@@ -145,9 +144,9 @@ class StdImgBlockIterBatches:
             self.img_info[img.name]["pxl_size"] = rsgislib.imageutils.get_img_size(
                 img.file_name
             )
-            self.img_info[img.name][
-                "epsg"
-            ] = rsgislib.imageutils.get_epsg_proj_from_img(img.file_name)
+            self.img_info[img.name]["epsg"] = (
+                rsgislib.imageutils.get_epsg_proj_from_img(img.file_name)
+            )
             if self.img_info[img.name]["epsg"] is None:
                 raise rsgislib.RSGISPyException(
                     "The input image ({}) does not have a "

--- a/python/rsgislib/imageutils/tilingutils.py
+++ b/python/rsgislib/imageutils/tilingutils.py
@@ -126,7 +126,7 @@ def create_min_data_tiles(
     )
     rastergis.pop_rat_img_stats(tileClumpsImage, True, True)
 
-    if not maskIntersect is None:
+    if maskIntersect is not None:
         bs = []
         bs.append(rastergis.BandAttStats(band=1, maxField="Mask"))
         rastergis.populate_rat_with_stats(maskIntersect, tileClumpsImage, bs)
@@ -166,7 +166,7 @@ def create_min_data_tiles(
         tileClumpsImage, inputImage, outclumpsFile, "KEA", "Selected", "NoDataClumps"
     )
 
-    if not outshp is None:
+    if outshp is not None:
         tilesDS = gdal.Open(outclumpsFile, gdal.GA_ReadOnly)
         tilesDSBand = tilesDS.GetRasterBand(1)
 

--- a/python/rsgislib/regression/__init__.py
+++ b/python/rsgislib/regression/__init__.py
@@ -58,10 +58,10 @@ def get_regression_stats(ref_data, pred_data, n_vars=1):
         acc_metrics["r2"] = sklearn.metrics.r2_score(
             ref_data[..., i], pred_data[..., i]
         )
-        acc_metrics[
-            "explained_variance_score"
-        ] = sklearn.metrics.explained_variance_score(
-            ref_data[..., i], pred_data[..., i]
+        acc_metrics["explained_variance_score"] = (
+            sklearn.metrics.explained_variance_score(
+                ref_data[..., i], pred_data[..., i]
+            )
         )
         acc_metrics["median_absolute_error"] = sklearn.metrics.median_absolute_error(
             ref_data[..., i], pred_data[..., i]

--- a/python/rsgislib/regression/regresssklearn.py
+++ b/python/rsgislib/regression/regresssklearn.py
@@ -2,10 +2,15 @@
 
 import math
 
-from sklearn.ensemble import ExtraTreesRegressor
-from sklearn.model_selection import GridSearchCV
-
 import rsgislib
+
+TQDM_AVAIL = True
+try:
+    import tqdm
+except ImportError:
+    import rios.cuiprogress
+
+    TQDM_AVAIL = False
 
 
 def get_ann_obj_params(n_predictors):
@@ -371,16 +376,14 @@ def apply_regress_sklearn_mdl(
     """
 
     import numpy
-    from rios import applier, cuiprogress
+    from rios import applier
 
     import rsgislib.imageutils
 
-    try:
-        import tqdm
-
+    if TQDM_AVAIL:
         progress_bar = rsgislib.TQDMProgressBar()
-    except:
-        progress_bar = cuiprogress.GDALProgressBar()
+    else:
+        progress_bar = rios.cuiprogress.GDALProgressBar()
 
     # Convert from GDAL band index (start 1) to Numpy Array index (start 0)
     predictor_img_bands_arr = numpy.array(predictor_img_bands)

--- a/python/rsgislib/segmentation/shepherdseg.py
+++ b/python/rsgislib/segmentation/shepherdseg.py
@@ -175,7 +175,7 @@ def run_shepherd_segmentation(
     # Select Image Bands if required
     inputImgBands = input_img
     selectBands = False
-    if not bands is None:
+    if bands is not None:
         print("Subsetting the image bands")
         selectBands = True
         inputImgBands = os.path.join(
@@ -332,7 +332,7 @@ def run_shepherd_segmentation(
         rsgislib.rastergis.pop_rat_img_stats(out_clumps_img, True, True)
 
     # Create mean image if required.
-    if not (out_mean_img is None):
+    if out_mean_img is not None:
         rsgislib.segmentation.mean_image(
             input_img, out_clumps_img, out_mean_img, gdalformat, input_datatype
         )
@@ -342,7 +342,7 @@ def run_shepherd_segmentation(
     if save_process_stats:
         gdalDS = gdal.Open(input_img, gdal.GA_ReadOnly)
         geotransform = gdalDS.GetGeoTransform()
-        if not geotransform is None:
+        if geotransform is not None:
             xTL = geotransform[0]
             yTL = geotransform[3]
 
@@ -495,7 +495,7 @@ def run_shepherd_segmentation_pre_calcd_stats(
     # Select Image Bands if required
     inputImgBands = input_img
     selectBands = False
-    if not bands is None:
+    if bands is not None:
         print("Subsetting the image bands")
         selectBands = True
         inputImgBands = os.path.join(
@@ -634,7 +634,7 @@ def run_shepherd_segmentation_pre_calcd_stats(
         rsgislib.rastergis.pop_rat_img_stats(out_clumps_img, True, True)
 
     # Create mean image if required.
-    if not (out_mean_img is None):
+    if out_mean_img is not None:
         rsgislib.segmentation.mean_image(
             input_img, out_clumps_img, out_mean_img, gdalformat, input_datatype
         )

--- a/python/rsgislib/timeseries/modelfitting.py
+++ b/python/rsgislib/timeseries/modelfitting.py
@@ -44,6 +44,14 @@ from sklearn import linear_model
 
 import rsgislib
 
+TQDM_AVAIL = True
+try:
+    import tqdm
+except ImportError:
+    import rios.cuiprogress
+
+    TQDM_AVAIL = False
+
 
 # could have two functions- one for Lasso, one for OLS
 # all of the stored class variables should work for either model type
@@ -327,13 +335,10 @@ def get_ST_model_coeffs(
     app.setOutputDriverName(gdalformat)
 
     # Set progress
-    try:
-        import tqdm
-
-        progress_bar = rsgislib.TQDMProgressBar()
-    except:
-        progress_bar = cuiprogress.GDALProgressBar()
-    app.progress = progress_bar
+    if TQDM_AVAIL:
+        app.progress = rsgislib.TQDMProgressBar()
+    else:
+        app.progress = rios.cuiprogress.GDALProgressBar()
 
     # Set that pyramids and statistics are not calculated.
     app.omitPyramids = True
@@ -474,13 +479,10 @@ def predict_for_date(date, input_path, output_path, gdalformat="KEA", num_proces
     app.setOutputDriverName(gdalformat)
 
     # Set progress
-    try:
-        import tqdm
-
-        progress_bar = rsgislib.TQDMProgressBar()
-    except:
-        progress_bar = cuiprogress.GDALProgressBar()
-    app.progress = progress_bar
+    if TQDM_AVAIL:
+        app.progress = rsgislib.TQDMProgressBar()
+    else:
+        app.progress = rios.cuiprogress.GDALProgressBar()
 
     # Set that pyramids and statistics are not calculated.
     app.omitPyramids = True

--- a/python/rsgislib/timeseries/modelfitting.py
+++ b/python/rsgislib/timeseries/modelfitting.py
@@ -39,7 +39,7 @@ import sys
 from datetime import datetime
 
 import numpy
-from rios import applier, cuiprogress, fileinfo
+from rios import applier, fileinfo
 from sklearn import linear_model
 
 import rsgislib

--- a/python/rsgislib/timeseries/robustfitoutliners.py
+++ b/python/rsgislib/timeseries/robustfitoutliners.py
@@ -6,7 +6,7 @@ from datetime import datetime
 
 import numpy
 import statsmodels.api
-from rios import applier, cuiprogress, fileinfo
+from rios import applier, fileinfo
 
 import rsgislib
 import rsgislib.imageutils

--- a/python/rsgislib/timeseries/robustfitoutliners.py
+++ b/python/rsgislib/timeseries/robustfitoutliners.py
@@ -11,6 +11,14 @@ from rios import applier, cuiprogress, fileinfo
 import rsgislib
 import rsgislib.imageutils
 
+TQDM_AVAIL = True
+try:
+    import tqdm
+except ImportError:
+    import rios.cuiprogress
+
+    TQDM_AVAIL = False
+
 
 class RobustModel(object):
     def __init__(self, datetimes, num_years):
@@ -168,14 +176,10 @@ def get_ST_masks(
     app.setWindowXsize(1)
     app.setWindowYsize(1)
 
-    # Set progress
-    try:
-        import tqdm
-
-        progress_bar = rsgislib.TQDMProgressBar()
-    except:
-        progress_bar = cuiprogress.GDALProgressBar()
-    app.progress = progress_bar
+    if TQDM_AVAIL:
+        app.progress = rsgislib.TQDMProgressBar()
+    else:
+        app.progress = rios.cuiprogress.GDALProgressBar()
 
     # Set output file type
     app.setOutputDriverName(gdal_format)

--- a/python/rsgislib/tools/httptools.py
+++ b/python/rsgislib/tools/httptools.py
@@ -106,7 +106,7 @@ def send_http_json_request(
     else:
         params_data = data
 
-    if api_key == None:
+    if api_key is None:
         response = requests.post(url, params_data, headers=header_data)
     else:
         if header_data is not None:
@@ -117,7 +117,7 @@ def send_http_json_request(
 
     try:
         http_status_code = response.status_code
-        if response == None:
+        if response is None:
             raise rsgislib.RSGISPyException("No output from service")
 
         if http_status_code == 404:

--- a/python/rsgislib/tools/mapping.py
+++ b/python/rsgislib/tools/mapping.py
@@ -632,7 +632,7 @@ def create_raster_img_map(
     img_no_data_val: float = None,
     stch_min_max_vals: Union[Dict, List[Dict]] = None,
     stch_n_stdevs: float = 2.0,
-    img_alpha: float=1.0,
+    img_alpha: float = 1.0,
     scale_bar_loc: str = "upper right",
     plot_zorder: float = 1,
 ):
@@ -716,7 +716,13 @@ def create_raster_img_map(
     if len(img_bands) == 1:
         clr_map = "gist_gray"
 
-    ax.imshow(img_data_strch, cmap=clr_map, extent=img_coords, alpha=img_alpha, zorder=plot_zorder)
+    ax.imshow(
+        img_data_strch,
+        cmap=clr_map,
+        extent=img_coords,
+        alpha=img_alpha,
+        zorder=plot_zorder,
+    )
     ax.set_xlim([img_coords[0], img_coords[1]])
     ax.set_ylim([img_coords[2], img_coords[3]])
 

--- a/python/rsgislib/tools/mapping.py
+++ b/python/rsgislib/tools/mapping.py
@@ -525,7 +525,7 @@ def create_vec_lyr_map(
 
     """
     n_vec_lyrs = 1
-    if type(gp_vecs) is list:
+    if isinstance(gp_vecs, list):
         n_vec_lyrs = len(gp_vecs)
     else:
         # Create list of one
@@ -541,7 +541,7 @@ def create_vec_lyr_map(
         else:
             gp_vec_sub = gp_vec
 
-        if type(vec_fill_clrs) is list:
+        if isinstance(vec_fill_clrs, list):
             if len(vec_fill_clrs) != n_vec_lyrs:
                 raise rsgislib.RSGISPyException(
                     "Number of fill colours not same as number of vector layers"
@@ -550,7 +550,7 @@ def create_vec_lyr_map(
         else:
             vec_fill_clr = vec_fill_clrs
 
-        if type(vec_line_clrs) is list:
+        if isinstance(vec_line_clrs, list):
             if len(vec_line_clrs) != n_vec_lyrs:
                 raise rsgislib.RSGISPyException(
                     "Number of line colours not same as number of vector layers"
@@ -559,7 +559,7 @@ def create_vec_lyr_map(
         else:
             vec_line_clr = vec_line_clrs
 
-        if type(vec_line_widths) is list:
+        if isinstance(vec_line_widths, list):
             if len(vec_line_widths) != n_vec_lyrs:
                 raise rsgislib.RSGISPyException(
                     "Number of line widths not same as number of vector layers"
@@ -568,7 +568,7 @@ def create_vec_lyr_map(
         else:
             vec_line_width = vec_line_widths
 
-        if type(vec_fill_alphas) is list:
+        if isinstance(vec_fill_alphas, list):
             if len(vec_fill_alphas) != n_vec_lyrs:
                 raise rsgislib.RSGISPyException(
                     "Number of fill alphas not same as number of vector layers"
@@ -577,7 +577,7 @@ def create_vec_lyr_map(
         else:
             vec_fill_alpha = vec_fill_alphas
 
-        if type(plot_zorders) is list:
+        if isinstance(plot_zorders, list):
             if len(plot_zorders) != n_vec_lyrs:
                 raise rsgislib.RSGISPyException(
                     "Number of fill colours not same as number of vector layers"

--- a/python/rsgislib/tools/plotting.py
+++ b/python/rsgislib/tools/plotting.py
@@ -1353,7 +1353,7 @@ def manual_stretch_np_arr(
         arr_data_out = arr_data_out.astype(float)
 
     if len(arr_shp) == 2:
-        if type(min_max_vals) is not dict:
+        if not isinstance(min_max_vals, dict):
             raise rsgislib.RSGISPyException(
                 "Just 1 dimension within arr_data and therefore "
                 "min_max_vals variable must be a dict."
@@ -1370,7 +1370,7 @@ def manual_stretch_np_arr(
 
         arr_data_out = (((arr_data_out - min_val) / range_val) * out_gain) + out_off
     else:
-        if type(min_max_vals) is not list:
+        if not isinstance(min_max_vals, list):
             raise rsgislib.RSGISPyException(
                 "arr_data has more than 1 dimension and therefore "
                 "min_max_vals variable must be a list."

--- a/python/rsgislib/tools/plotting.py
+++ b/python/rsgislib/tools/plotting.py
@@ -658,20 +658,20 @@ def plot_histogram_threshold(
 
 
 def plot_vec_fields(
-        vec_file: str,
-        vec_lyr: str,
-        out_plot_file: str,
-        x_plt_field: str,
-        y_plt_field: str,
-        x_lbl: str,
-        y_lbl: str,
-        title: str,
-        feat_id_field: str = None,
-        x_field_no_data: float = None,
-        y_field_no_data: float = None,
-        plt_width: int = 18,
-        plt_height: int = 6,
-        plt_line: bool = True,
+    vec_file: str,
+    vec_lyr: str,
+    out_plot_file: str,
+    x_plt_field: str,
+    y_plt_field: str,
+    x_lbl: str,
+    y_lbl: str,
+    title: str,
+    feat_id_field: str = None,
+    x_field_no_data: float = None,
+    y_field_no_data: float = None,
+    plt_width: int = 18,
+    plt_height: int = 6,
+    plt_line: bool = True,
 ):
     """
     A function which plots two variables from a vector layer.

--- a/python/rsgislib/tools/sensors.py
+++ b/python/rsgislib/tools/sensors.py
@@ -120,9 +120,9 @@ def read_sen2_l2a_mtd_to_dict(mtd_header_file: str):
             "Data Take Tag is None - is this a Sentinel-2 L2A header"
         )
     out_header_dict["Product_Info"]["datatake"] = dict()
-    out_header_dict["Product_Info"]["datatake"][
-        "datatakeIdentifier"
-    ] = data_take_tag.attrib["datatakeIdentifier"].strip()
+    out_header_dict["Product_Info"]["datatake"]["datatakeIdentifier"] = (
+        data_take_tag.attrib["datatakeIdentifier"].strip()
+    )
     out_header_dict["Product_Info"]["datatake"]["SPACECRAFT_NAME"] = data_take_tag.find(
         "SPACECRAFT_NAME"
     ).text.strip()
@@ -137,12 +137,12 @@ def read_sen2_l2a_mtd_to_dict(mtd_header_file: str):
     out_header_dict["Product_Info"]["datatake"][
         "DATATAKE_SENSING_START"
     ] = datatake_sense_time
-    out_header_dict["Product_Info"]["datatake"][
-        "SENSING_ORBIT_NUMBER"
-    ] = data_take_tag.find("SENSING_ORBIT_NUMBER").text.strip()
-    out_header_dict["Product_Info"]["datatake"][
-        "SENSING_ORBIT_DIRECTION"
-    ] = data_take_tag.find("SENSING_ORBIT_DIRECTION").text.strip()
+    out_header_dict["Product_Info"]["datatake"]["SENSING_ORBIT_NUMBER"] = (
+        data_take_tag.find("SENSING_ORBIT_NUMBER").text.strip()
+    )
+    out_header_dict["Product_Info"]["datatake"]["SENSING_ORBIT_DIRECTION"] = (
+        data_take_tag.find("SENSING_ORBIT_DIRECTION").text.strip()
+    )
 
     query_options_tag = product_info_tag.find("Query_Options")
     if query_options_tag is None:
@@ -150,9 +150,9 @@ def read_sen2_l2a_mtd_to_dict(mtd_header_file: str):
             "Query Options Tag is None - is this a Sentinel-2 L2A header"
         )
     out_header_dict["Product_Info"]["Query_Options"] = dict()
-    out_header_dict["Product_Info"]["Query_Options"][
-        "PRODUCT_FORMAT"
-    ] = query_options_tag.find("PRODUCT_FORMAT").text.strip()
+    out_header_dict["Product_Info"]["Query_Options"]["PRODUCT_FORMAT"] = (
+        query_options_tag.find("PRODUCT_FORMAT").text.strip()
+    )
 
     product_organisation_tag = product_info_tag.find("Product_Organisation")
     if product_organisation_tag is None:

--- a/python/rsgislib/tools/sensors.py
+++ b/python/rsgislib/tools/sensors.py
@@ -65,13 +65,11 @@ def read_sen2_l2a_mtd_to_dict(mtd_header_file: str):
     general_info_tag = root.find(
         "{https://psd-14.sentinel2.eo.esa.int/PSD/User_Product_Level-2A.xsd}General_Info"
     )
-    if general_info_tag == None:
+    if general_info_tag is None:
         raise rsgislib.RSGISPyException(
             "Cannot open top level section 'General_Info' - "
             "is this really a Sentinel-2 image file?"
         )
-    else:
-        hdr_file_version = "psd14"
 
     product_info_tag = general_info_tag.find("Product_Info")
     if product_info_tag is None:

--- a/python/rsgislib/tools/stats.py
+++ b/python/rsgislib/tools/stats.py
@@ -196,7 +196,9 @@ def corr_feature_selection(df, dep_vars, ind_vars, n_min_clusters=3, n_max_clust
             )
 
         clf = sklearn.cluster.FeatureAgglomeration(
-            n_clusters=n_clusters, metric=_pearson_affinity, linkage="complete",
+            n_clusters=n_clusters,
+            metric=_pearson_affinity,
+            linkage="complete",
         )
         clf.fit(X)
 

--- a/python/rsgislib/tools/testimages.py
+++ b/python/rsgislib/tools/testimages.py
@@ -8,6 +8,14 @@ import os
 from typing import List
 import rsgislib
 
+TQDM_AVAIL = True
+try:
+    import tqdm
+except ImportError:
+    import rios.cuiprogress
+
+    TQDM_AVAIL = False
+
 
 def create_random_int_img(
     output_img: str,
@@ -65,12 +73,10 @@ def create_random_int_img(
         no_data_val=0,
     )
 
-    try:
+    if TQDM_AVAIL:
         progress_bar = rsgislib.TQDMProgressBar()
-    except:
-        from rios import cuiprogress
-
-        progress_bar = cuiprogress.GDALProgressBar()
+    else:
+        progress_bar = rios.cuiprogress.GDALProgressBar()
 
     infiles = applier.FilenameAssociations()
     infiles.image = tmp_ref_img

--- a/python/rsgislib/tools/utils.py
+++ b/python/rsgislib/tools/utils.py
@@ -125,7 +125,7 @@ def str_to_float(str_val: str, err_val: float = None) -> float:
     try:
         out_float = float(str_val)
     except ValueError:
-        if not err_val is None:
+        if err_val is not None:
             out_float = float(err_val)
         else:
             raise rsgislib.RSGISPyException(
@@ -155,7 +155,7 @@ def str_to_int(str_val: str, err_val: int = None) -> int:
             tmp_float = float(str_val)
             out_int = int(math.floor(tmp_float + 0.5))
         except ValueError:
-            if not err_val is None:
+            if err_val is not None:
                 out_int = int(err_val)
             else:
                 raise rsgislib.RSGISPyException(
@@ -966,14 +966,14 @@ def dict_struct_get_date_value(
         else:
             raise rsgislib.RSGISPyException("Could not find '{}'".format(steps_str))
 
-    if type(date_format) is str:
+    if isinstance(date_format, str):
         try:
             out_date_obj = datetime.datetime.strptime(
                 curr_dict_struct_obj, date_format
             ).date()
         except Exception as e:
             raise rsgislib.RSGISPyException(e)
-    elif type(date_format) is list:
+    elif isinstance(date_format, list):
         found = False
         except_obj = None
         for date_format_str in date_format:
@@ -1019,14 +1019,14 @@ def dict_struct_get_datetime_value(
             raise rsgislib.RSGISPyException("Could not find '{}'".format(steps_str))
 
     curr_dict_struct_obj = curr_dict_struct_obj.replace("Z", "")
-    if type(date_time_format) is str:
+    if isinstance(date_time_format, str):
         try:
             out_datetime_obj = datetime.datetime.strptime(
                 curr_dict_struct_obj, date_time_format
             )
         except Exception as e:
             raise rsgislib.RSGISPyException(e)
-    elif type(date_time_format) is list:
+    elif isinstance(date_time_format, list):
         found = False
         except_obj = None
         for date_time_format_str in date_time_format:

--- a/python/rsgislib/tools/visualisation.py
+++ b/python/rsgislib/tools/visualisation.py
@@ -16,6 +16,14 @@ import rsgislib.tools.projection
 import rsgislib.tools.tilecacheutils
 import rsgislib.tools.utils
 
+TQDM_AVAIL = True
+try:
+    import tqdm
+except ImportError:
+    import rios.cuiprogress
+
+    TQDM_AVAIL = False
+
 
 def create_kmz_img(
     input_img: str,
@@ -1352,14 +1360,10 @@ def burn_in_binary_msk(
             "the msk_colour array should be equal."
         )
 
-    try:
-        import tqdm
-
+    if TQDM_AVAIL:
         progress_bar = rsgislib.TQDMProgressBar()
-    except:
-        from rios import cuiprogress
-
-        progress_bar = cuiprogress.GDALProgressBar()
+    else:
+        progress_bar = rios.cuiprogress.GDALProgressBar()
 
     infiles = applier.FilenameAssociations()
     infiles.base_image = base_image

--- a/python/rsgislib/vectorattrs/__init__.py
+++ b/python/rsgislib/vectorattrs/__init__.py
@@ -939,8 +939,8 @@ def sort_vec_lyr(
 
     out_format = rsgislib.vectorutils.check_format_name(out_format)
 
-    if type(sort_by) is list:
-        if type(ascending) is not list:
+    if isinstance(sort_by, list):
+        if not isinstance(ascending, list):
             raise rsgislib.RSGISPyException(
                 "If sort_by is a list then ascending must be too."
             )

--- a/python/rsgislib/vectorgeoms/__init__.py
+++ b/python/rsgislib/vectorgeoms/__init__.py
@@ -3666,7 +3666,9 @@ def thin_vector_geoms(
     grid_gdf["unq_id"] = numpy.arange(1, (grid_gdf.shape[0]) + 1, 1, dtype=int)
 
     print("Perform Join")
-    pts_join_gdf = geopandas.sjoin(pts_gdf, grid_gdf, how="inner", predicate="intersects")
+    pts_join_gdf = geopandas.sjoin(
+        pts_gdf, grid_gdf, how="inner", predicate="intersects"
+    )
 
     pts_join_gdf.drop_duplicates(
         subset="unq_id", keep="first", inplace=True, ignore_index=False

--- a/python/rsgislib/vectorutils/__init__.py
+++ b/python/rsgislib/vectorutils/__init__.py
@@ -629,7 +629,7 @@ def get_vec_lyrs_lst(vec_file: str) -> List[str]:
     for lyr_idx in range(gdal_dataset.GetLayerCount()):
         lyr = gdal_dataset.GetLayerByIndex(lyr_idx)
         t_lyr_name = lyr.GetName()
-        if not t_lyr_name in layer_list:
+        if t_lyr_name not in layer_list:
             layer_list.append(t_lyr_name)
     gdal_dataset = None
     return layer_list
@@ -1071,8 +1071,6 @@ def get_att_lst_select_feats(
     :return: list of dictionaries with the output values.
 
     """
-
-    att_vals = []
     try:
         dsVecFile = gdal.OpenEx(vec_file, gdal.OF_READONLY)
         if dsVecFile is None:
@@ -1172,8 +1170,6 @@ def get_att_lst_select_feats_lyr_objs(
     :return: list of dictionaries with the output values.
 
     """
-
-    att_vals = []
     try:
         if vec_lyr_obj is None:
             raise rsgislib.RSGISPyException(
@@ -1433,8 +1429,6 @@ def select_intersect_feats(
     if lyrROIVecObj is None:
         raise rsgislib.RSGISPyException("Could not find layer '" + vec_roi_lyr + "'")
 
-    lyrDefn = vec_lyr_obj.GetLayerDefn()
-
     mem_driver = ogr.GetDriverByName("MEMORY")
     mem_roi_ds = mem_driver.CreateDataSource("MemSelData")
     mem_roi_lyr = mem_roi_ds.CopyLayer(lyrROIVecObj, vec_roi_lyr, ["OVERWRITE=YES"])
@@ -1476,8 +1470,6 @@ def export_spatial_select_feats(
     :param out_format: the output vector layer type.
 
     """
-
-    att_vals = []
     try:
         dsVecFile = gdal.OpenEx(vec_file, gdal.OF_READONLY)
         if dsVecFile is None:
@@ -1529,7 +1521,6 @@ def export_spatial_select_feats(
         for i in range(srcLayerDefn.GetFieldCount()):
             fieldDefn = srcLayerDefn.GetFieldDefn(i)
             result_lyr.CreateField(fieldDefn)
-        rsltLayerDefn = result_lyr.GetLayerDefn()
 
         counter = 0
         openTransaction = False
@@ -1700,7 +1691,6 @@ def subset_envs_vec_lyr_obj(
     counter = 0
     vec_lyr_obj.ResetReading()
     print("Started .0.", end="", flush=True)
-    outenvs = []
     # loop through the input features
     inFeature = vec_lyr_obj.GetNextFeature()
     while inFeature:
@@ -2542,7 +2532,7 @@ def spatial_select(
     base_gpdf = geopandas.read_file(vec_file, layer=vec_lyr)
     roi_gpdf = geopandas.read_file(vec_roi_file, layer=vec_roi_lyr)
     base_gpdf["msk_rsgis_sel"] = numpy.zeros((base_gpdf.shape[0]), dtype=bool)
-    geoms = list()
+
     for i in tqdm.tqdm(range(roi_gpdf.shape[0])):
         inter = base_gpdf["geometry"].intersects(roi_gpdf.iloc[i]["geometry"])
         base_gpdf.loc[inter, "msk_rsgis_sel"] = True

--- a/python/rsgislib/vectorutils/createvectors.py
+++ b/python/rsgislib/vectorutils/createvectors.py
@@ -11,6 +11,13 @@ from osgeo import gdal, ogr, osr
 
 import rsgislib
 
+TQDM_AVAIL = True
+try:
+    import tqdm
+except ImportError:
+    import rios.cuiprogress
+    TQDM_AVAIL = False
+
 gdal.UseExceptions()
 
 
@@ -145,12 +152,10 @@ def vectorise_pxls_to_pts(
     import rsgislib.imageutils
     import rsgislib.vectorutils
 
-    try:
+    if TQDM_AVAIL:
         progress_bar = rsgislib.TQDMProgressBar()
-    except:
-        from rios import cuiprogress
-
-        progress_bar = cuiprogress.GDALProgressBar()
+    else:
+        progress_bar = rios.cuiprogress.GDALProgressBar()
 
     if os.path.exists(out_vec_file):
         if del_exist_vec:

--- a/python/rsgislib/vectorutils/createvectors.py
+++ b/python/rsgislib/vectorutils/createvectors.py
@@ -276,7 +276,7 @@ def extract_image_footprint(
     )
 
     out_vec_tmp_file = out_vec_file
-    if not (reproj_to is None):
+    if reproj_to is not None:
         out_vec_tmp_file = os.path.join(
             tmp_dir, in_img_base + "_" + uid_str + "_initVecOut.gpkg"
         )
@@ -303,7 +303,7 @@ def extract_image_footprint(
         out_vec_tmp_file, out_vec_lyr, "FileName", ogr.OFTString, file_name
     )
 
-    if not (reproj_to is None):
+    if reproj_to is not None:
         if os.path.exists(out_vec_file):
             rsgislib.vectorutils.delete_vector_file(out_vec_file)
 
@@ -331,7 +331,7 @@ def extract_image_footprint(
 
         shutil.rmtree(tmp_dir)
     else:
-        if not (reproj_to is None):
+        if reproj_to is not None:
             driver = ogr.GetDriverByName("ESRI Shapefile")
             driver.DeleteDataSource(out_vec_tmp_file)
 
@@ -669,12 +669,12 @@ def create_poly_vec_bboxs(
         add_atts = False
         if (atts is not None) and (att_types is not None):
             n_atts = 0
-            if not "names" in att_types:
+            if "names" not in att_types:
                 raise rsgislib.RSGISPyException(
                     'attTypes must include a list for "names"'
                 )
             n_atts = len(att_types["names"])
-            if not "types" in att_types:
+            if "types" not in att_types:
                 raise rsgislib.RSGISPyException(
                     'attTypes must include a list for "types"'
                 )
@@ -817,12 +817,12 @@ def write_pts_to_vec(
         addAtts = False
         if (atts is not None) and (att_types is not None):
             nAtts = 0
-            if not "names" in att_types:
+            if "names" not in att_types:
                 raise rsgislib.RSGISPyException(
                     'attTypes must include a list for "names"'
                 )
             nAtts = len(att_types["names"])
-            if not "types" in att_types:
+            if "types" not in att_types:
                 raise rsgislib.RSGISPyException(
                     'attTypes must include a list for "types"'
                 )

--- a/python/rsgislib/vectorutils/createvectors.py
+++ b/python/rsgislib/vectorutils/createvectors.py
@@ -16,6 +16,7 @@ try:
     import tqdm
 except ImportError:
     import rios.cuiprogress
+
     TQDM_AVAIL = False
 
 gdal.UseExceptions()

--- a/python_tests/test_changedetect_pxloutlierchng.py
+++ b/python_tests/test_changedetect_pxloutlierchng.py
@@ -23,10 +23,7 @@ DATA_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "data")
 CHANGEDETECT_DATA_DIR = os.path.join(DATA_DIR, "changedetect")
 
 
-#@pytest.mark.skipif(PYOD_NOT_AVAIL, reason="pyod dependency not available")
-@pytest.mark.skip(
-    reason="TODO: Function need updating to not use rios.imagereader.ImageReader"
-)
+@pytest.mark.skipif(PYOD_NOT_AVAIL, reason="pyod dependency not available")
 def test_find_class_pyod_outliers(tmp_path):
     import rsgislib.changedetect.pxloutlierchng
     import pyod.models.knn
@@ -51,12 +48,9 @@ def test_find_class_pyod_outliers(tmp_path):
     assert os.path.exists(output_img) and os.path.exists(out_scores_img)
 
 
-#@pytest.mark.skipif(
-#    (MATPLOTLIB_NOT_AVAIL or SCIPY_NOT_AVAIL),
-#    reason="matplotlib or scipy dependencies not available",
-#)
-@pytest.mark.skip(
-    reason="TODO: Function need updating to not use rios.imagereader.ImageReader"
+@pytest.mark.skipif(
+    (MATPLOTLIB_NOT_AVAIL or SCIPY_NOT_AVAIL),
+    reason="matplotlib or scipy dependencies not available",
 )
 def test_find_class_kurt_skew_outliers(tmp_path):
     from rsgislib.changedetect.pxloutlierchng import find_class_kurt_skew_outliers
@@ -86,10 +80,7 @@ def test_find_class_kurt_skew_outliers(tmp_path):
     assert os.path.exists(output_img)
 
 
-# @pytest.mark.skipif(MATPLOTLIB_NOT_AVAIL, reason="matplotlib dependency not available")
-@pytest.mark.skip(
-    reason="TODO: Function need updating to not use rios.imagereader.ImageReader"
-)
+@pytest.mark.skipif(MATPLOTLIB_NOT_AVAIL, reason="matplotlib dependency not available")
 def test_find_class_otsu_outliers(tmp_path):
     from rsgislib.changedetect.pxloutlierchng import find_class_otsu_outliers
 
@@ -113,10 +104,7 @@ def test_find_class_otsu_outliers(tmp_path):
     assert os.path.exists(output_img)
 
 
-# @pytest.mark.skipif(MATPLOTLIB_NOT_AVAIL, reason="matplotlib dependency not available")
-@pytest.mark.skip(
-    reason="TODO: Function need updating to not use rios.imagereader.ImageReader"
-)
+@pytest.mark.skipif(MATPLOTLIB_NOT_AVAIL, reason="matplotlib dependency not available")
 def test_find_class_li_outliers(tmp_path):
     from rsgislib.changedetect.pxloutlierchng import find_class_li_outliers
 

--- a/python_tests/test_classification_clustersklearn.py
+++ b/python_tests/test_classification_clustersklearn.py
@@ -10,10 +10,7 @@ except ImportError:
 DATA_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "data")
 
 
-# @pytest.mark.skipif(SKLEARN_NOT_AVAIL, reason="scikit-learn dependency not available")
-@pytest.mark.skip(
-    reason="TODO: Function need updating to not use rios.imagereader.ImageReader"
-)
+@pytest.mark.skipif(SKLEARN_NOT_AVAIL, reason="scikit-learn dependency not available")
 def test_img_pixel_sample_cluster(tmp_path):
     import rsgislib.classification.clustersklearn
 
@@ -25,10 +22,7 @@ def test_img_pixel_sample_cluster(tmp_path):
     assert os.path.exists(output_img)
 
 
-# @pytest.mark.skipif(SKLEARN_NOT_AVAIL, reason="scikit-learn dependency not available")
-@pytest.mark.skip(
-    reason="TODO: Function need updating to not use rios.imagereader.ImageReader"
-)
+@pytest.mark.skipif(SKLEARN_NOT_AVAIL, reason="scikit-learn dependency not available")
 def test_img_pixel_tiled_cluster(tmp_path):
     import rsgislib.classification.clustersklearn
 

--- a/python_tests/test_classification_clustersklearn.py
+++ b/python_tests/test_classification_clustersklearn.py
@@ -10,7 +10,7 @@ except ImportError:
 DATA_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "data")
 
 
-#@pytest.mark.skipif(SKLEARN_NOT_AVAIL, reason="scikit-learn dependency not available")
+# @pytest.mark.skipif(SKLEARN_NOT_AVAIL, reason="scikit-learn dependency not available")
 @pytest.mark.skip(
     reason="TODO: Function need updating to not use rios.imagereader.ImageReader"
 )
@@ -25,7 +25,7 @@ def test_img_pixel_sample_cluster(tmp_path):
     assert os.path.exists(output_img)
 
 
-#@pytest.mark.skipif(SKLEARN_NOT_AVAIL, reason="scikit-learn dependency not available")
+# @pytest.mark.skipif(SKLEARN_NOT_AVAIL, reason="scikit-learn dependency not available")
 @pytest.mark.skip(
     reason="TODO: Function need updating to not use rios.imagereader.ImageReader"
 )

--- a/python_tests/test_imagecalc.py
+++ b/python_tests/test_imagecalc.py
@@ -17,9 +17,6 @@ except ImportError:
     SKLEARN_NOT_AVAIL = True
 
 
-@pytest.mark.skip(
-    reason="TODO: Function need updating to not use rios.imagereader.ImageReader"
-)
 def test_count_pxls_of_val_band1():
     import rsgislib.imagecalc
 
@@ -35,9 +32,6 @@ def test_count_pxls_of_val_band1():
     )
 
 
-@pytest.mark.skip(
-    reason="TODO: Function need updating to not use rios.imagereader.ImageReader"
-)
 def test_count_pxls_of_val_band1_sel_vals():
     import rsgislib.imagecalc
 
@@ -46,9 +40,6 @@ def test_count_pxls_of_val_band1_sel_vals():
     assert (val_counts[0] == 612) and (val_counts[1] == 614)
 
 
-@pytest.mark.skip(
-    reason="TODO: Function need updating to not use rios.imagereader.ImageReader"
-)
 def test_count_pxls_of_val_all_bands():
     import rsgislib.imagecalc
 
@@ -585,7 +576,7 @@ def test_calc_img_rescale_multi_imgs(tmp_path):
     assert img_eq
 
 
-#@pytest.mark.skipif(SKLEARN_NOT_AVAIL, reason="scikit-learn dependency not available")
+# @pytest.mark.skipif(SKLEARN_NOT_AVAIL, reason="scikit-learn dependency not available")
 @pytest.mark.skip(
     reason="TODO: Function need updating to not use rios.imagereader.ImageReader"
 )
@@ -612,7 +603,7 @@ def test_perform_image_pca(tmp_path):
     assert os.path.exists(output_img) and os.path.exists(out_eigen_vec_file)
 
 
-#@pytest.mark.skipif(SKLEARN_NOT_AVAIL, reason="scikit-learn dependency not available")
+# @pytest.mark.skipif(SKLEARN_NOT_AVAIL, reason="scikit-learn dependency not available")
 @pytest.mark.skip(
     reason="TODO: Function need updating to not use rios.imagereader.ImageReader"
 )

--- a/python_tests/test_imagecalc.py
+++ b/python_tests/test_imagecalc.py
@@ -1038,3 +1038,30 @@ def test_mahalanobis_dist_to_img_filter(tmp_path):
         input_img, output_img, 5, "KEA", rsgislib.TYPE_32FLOAT
     )
     assert os.path.exists(output_img)
+
+
+def test_calc_split_win_thresholds_otsu(tmp_path):
+    import rsgislib.imagecalc
+
+    input_img = os.path.join(IMGCALC_DATA_DIR, "sen2_20210527_aber_ndvi.kea")
+
+    thres_vals = rsgislib.imagecalc.calc_split_win_thresholds(
+        input_img,
+        win_size=500,
+        thres_meth=rsgislib.THRES_METH_OTSU,
+        output_file=None,
+        no_data_val=0.0,
+        lower_valid=None,
+        upper_valid=None,
+        min_n_vals=100,
+        # thres_kwrds = None,
+    )
+
+    n_thres = len(thres_vals[1])
+    assert (
+        (n_thres == 4)
+        and ((thres_vals[1][0] - 0.335) < 0.01)
+        and ((thres_vals[1][1] - 0.692) < 0.01)
+        and ((thres_vals[1][2] - 0.461) < 0.01)
+        and ((thres_vals[1][3] - 0.708) < 0.01)
+    )

--- a/python_tests/test_imagecalc.py
+++ b/python_tests/test_imagecalc.py
@@ -576,10 +576,7 @@ def test_calc_img_rescale_multi_imgs(tmp_path):
     assert img_eq
 
 
-# @pytest.mark.skipif(SKLEARN_NOT_AVAIL, reason="scikit-learn dependency not available")
-@pytest.mark.skip(
-    reason="TODO: Function need updating to not use rios.imagereader.ImageReader"
-)
+@pytest.mark.skipif(SKLEARN_NOT_AVAIL, reason="scikit-learn dependency not available")
 def test_perform_image_pca(tmp_path):
     import rsgislib.imagecalc
 
@@ -603,10 +600,7 @@ def test_perform_image_pca(tmp_path):
     assert os.path.exists(output_img) and os.path.exists(out_eigen_vec_file)
 
 
-# @pytest.mark.skipif(SKLEARN_NOT_AVAIL, reason="scikit-learn dependency not available")
-@pytest.mark.skip(
-    reason="TODO: Function need updating to not use rios.imagereader.ImageReader"
-)
+@pytest.mark.skipif(SKLEARN_NOT_AVAIL, reason="scikit-learn dependency not available")
 def test_perform_image_mnf(tmp_path):
     import rsgislib.imagecalc
 

--- a/python_tests/test_imagecalc_specunmixing.py
+++ b/python_tests/test_imagecalc_specunmixing.py
@@ -443,7 +443,6 @@ def test_extract_avg_endmembers(tmp_path):
 
 
 def test_exhcon_linear_spec_unmix(tmp_path):
-    import rsgislib
     from rsgislib.imagecalc import specunmixing
     import rsgislib.imagecalc
 
@@ -464,7 +463,6 @@ def test_exhcon_linear_spec_unmix(tmp_path):
 
 @pytest.mark.skipif(PYSPTOOLS_NOT_AVAIL, reason="pysptools dependency not available")
 def test_spec_unmix_spts_ucls_noWeight(tmp_path):
-    import rsgislib
     from rsgislib.imagecalc import specunmixing
     import rsgislib.imagecalc
 
@@ -494,7 +492,6 @@ def test_spec_unmix_spts_ucls_noWeight(tmp_path):
 
 @pytest.mark.skipif(PYSPTOOLS_NOT_AVAIL, reason="pysptools dependency not available")
 def test_spec_unmix_spts_ucls_weight100(tmp_path):
-    import rsgislib
     from rsgislib.imagecalc import specunmixing
     import rsgislib.imagecalc
 
@@ -524,7 +521,6 @@ def test_spec_unmix_spts_ucls_weight100(tmp_path):
 
 @pytest.mark.skipif(PYSPTOOLS_NOT_AVAIL, reason="pysptools dependency not available")
 def test_spec_unmix_spts_nnls_noWeight(tmp_path):
-    import rsgislib
     from rsgislib.imagecalc import specunmixing
     import rsgislib.imagecalc
 
@@ -554,7 +550,6 @@ def test_spec_unmix_spts_nnls_noWeight(tmp_path):
 
 @pytest.mark.skipif(PYSPTOOLS_NOT_AVAIL, reason="pysptools dependency not available")
 def test_spec_unmix_spts_nnls_weight100(tmp_path):
-    import rsgislib
     from rsgislib.imagecalc import specunmixing
     import rsgislib.imagecalc
 
@@ -584,7 +579,6 @@ def test_spec_unmix_spts_nnls_weight100(tmp_path):
 
 @pytest.mark.skipif(PYSPTOOLS_NOT_AVAIL, reason="pysptools dependency not available")
 def test_spec_unmix_spts_fcls(tmp_path):
-    import rsgislib
     from rsgislib.imagecalc import specunmixing
     import rsgislib.imagecalc
 
@@ -613,7 +607,6 @@ def test_spec_unmix_spts_fcls(tmp_path):
 
 @pytest.mark.skipif(PYMCR_NOT_AVAIL, reason="pymcr dependency not available")
 def test_spec_unmix_pymcr_nnls_noWeight(tmp_path):
-    import rsgislib
     from rsgislib.imagecalc import specunmixing
     import rsgislib.imagecalc
 
@@ -643,7 +636,6 @@ def test_spec_unmix_pymcr_nnls_noWeight(tmp_path):
 
 @pytest.mark.skipif(PYMCR_NOT_AVAIL, reason="pymcr dependency not available")
 def test_spec_unmix_pymcr_nnls_weight100(tmp_path):
-    import rsgislib
     from rsgislib.imagecalc import specunmixing
     import rsgislib.imagecalc
 
@@ -673,7 +665,6 @@ def test_spec_unmix_pymcr_nnls_weight100(tmp_path):
 
 @pytest.mark.skipif(PYMCR_NOT_AVAIL, reason="pymcr dependency not available")
 def test_spec_unmix_pymcr_fcls(tmp_path):
-    import rsgislib
     from rsgislib.imagecalc import specunmixing
     import rsgislib.imagecalc
 
@@ -701,7 +692,6 @@ def test_spec_unmix_pymcr_fcls(tmp_path):
 
 
 def test_rescale_unmixing_results(tmp_path):
-    import rsgislib
     from rsgislib.imagecalc import specunmixing
     import rsgislib.imagecalc
 
@@ -722,7 +712,6 @@ def test_rescale_unmixing_results(tmp_path):
 
 
 def test_predict_refl_linear_unmixing(tmp_path):
-    import rsgislib
     from rsgislib.imagecalc import specunmixing
     import rsgislib.imagecalc
 
@@ -743,7 +732,6 @@ def test_predict_refl_linear_unmixing(tmp_path):
 
 
 def test_calc_unmixing_rmse_residual_err(tmp_path):
-    import rsgislib
     from rsgislib.imagecalc import specunmixing
     import rsgislib.imagecalc
 

--- a/python_tests/test_imageutils.py
+++ b/python_tests/test_imageutils.py
@@ -1071,20 +1071,14 @@ def test_perform_random_pxl_sample_in_mask_low_pxl_count(tmp_path):
     assert os.path.exists(output_img)
 
 
-@pytest.mark.skip(
-    reason="TODO: Function need updating to not use rios.imagereader.ImageReader"
-)
 def test_extract_img_pxl_sample():
     import rsgislib.imageutils
 
     input_img = os.path.join(DATA_DIR, "aber_osgb_multi_polys_rasters.kea")
     vals = rsgislib.imageutils.extract_img_pxl_sample(input_img, pxl_n_sample=10)
-    assert vals.shape[0] == 88165
+    assert vals.shape[0] == 88156
 
 
-@pytest.mark.skip(
-    reason="TODO: Function need updating to not use rios.imagereader.ImageReader"
-)
 def test_extract_img_pxl_vals_in_msk():
     import rsgislib.imageutils
 

--- a/python_tests/test_segentatation_skimgseg.py
+++ b/python_tests/test_segentatation_skimgseg.py
@@ -11,10 +11,7 @@ DATA_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "data")
 SEGMENT_DATA_DIR = os.path.join(DATA_DIR, "segment")
 
 
-#@pytest.mark.skipif(SKIMG_NOT_AVAIL, reason="scikit-image dependency not available")
-@pytest.mark.skip(
-    reason="TODO: Function need updating to not use rios.imagereader.ImageReader"
-)
+@pytest.mark.skipif(SKIMG_NOT_AVAIL, reason="scikit-image dependency not available")
 def test_perform_felsenszwalb_segmentation(tmp_path):
     import rsgislib.segmentation.skimgseg
 
@@ -40,10 +37,7 @@ def test_perform_felsenszwalb_segmentation(tmp_path):
     assert os.path.exists(out_clumps_img)
 
 
-#@pytest.mark.skipif(SKIMG_NOT_AVAIL, reason="scikit-image dependency not available")
-@pytest.mark.skip(
-    reason="TODO: Function need updating to not use rios.imagereader.ImageReader"
-)
+@pytest.mark.skipif(SKIMG_NOT_AVAIL, reason="scikit-image dependency not available")
 def test_perform_quickshift_segmentation(tmp_path):
     import rsgislib.segmentation.skimgseg
 
@@ -71,10 +65,7 @@ def test_perform_quickshift_segmentation(tmp_path):
     assert os.path.exists(out_clumps_img)
 
 
-#@pytest.mark.skipif(SKIMG_NOT_AVAIL, reason="scikit-image dependency not available")
-@pytest.mark.skip(
-    reason="TODO: Function need updating to not use rios.imagereader.ImageReader"
-)
+@pytest.mark.skipif(SKIMG_NOT_AVAIL, reason="scikit-image dependency not available")
 def test_perform_slic_segmentation(tmp_path):
     import rsgislib.segmentation.skimgseg
 
@@ -107,10 +98,7 @@ def test_perform_slic_segmentation(tmp_path):
     assert os.path.exists(out_clumps_img)
 
 
-#@pytest.mark.skipif(SKIMG_NOT_AVAIL, reason="scikit-image dependency not available")
-@pytest.mark.skip(
-    reason="TODO: Function need updating to not use rios.imagereader.ImageReader"
-)
+@pytest.mark.skipif(SKIMG_NOT_AVAIL, reason="scikit-image dependency not available")
 def test_perform_watershed_segmentation(tmp_path):
     import rsgislib.segmentation.skimgseg
 

--- a/python_tests/test_vectorutils.py
+++ b/python_tests/test_vectorutils.py
@@ -844,9 +844,6 @@ def test_check_validate_geometries(tmp_path):
     assert os.path.exists(out_vec_file)
 
 
-@pytest.mark.skip(
-    reason="TODO: Function need updating to not use rios.imagereader.ImageReader"
-)
 def test_does_vmsk_img_intersect(tmp_path):
     import rsgislib.vectorutils
 

--- a/python_tests/test_zonalstats.py
+++ b/python_tests/test_zonalstats.py
@@ -1250,7 +1250,7 @@ def test_msk_h5_smpls_to_finite_values(tmp_path):
     assert os.path.exists(out_h5_file)
 
 
-#@pytest.mark.skipif(H5PY_NOT_AVAIL, reason="h5py dependency not available")
+# @pytest.mark.skipif(H5PY_NOT_AVAIL, reason="h5py dependency not available")
 @pytest.mark.skip(
     reason="TODO: Function need updating to not use rios.imagereader.ImageReader"
 )
@@ -1282,7 +1282,7 @@ def test_extract_chip_zone_image_band_values_to_hdf_no_rot(tmp_path):
     assert os.path.exists(out_h5_file)
 
 
-#@pytest.mark.skipif(H5PY_NOT_AVAIL, reason="h5py dependency not available")
+# @pytest.mark.skipif(H5PY_NOT_AVAIL, reason="h5py dependency not available")
 @pytest.mark.skip(
     reason="TODO: Function need updating to not use rios.imagereader.ImageReader"
 )
@@ -1314,7 +1314,7 @@ def test_extract_chip_zone_image_band_values_to_hdf_with_rot(tmp_path):
     assert os.path.exists(out_h5_file)
 
 
-#@pytest.mark.skipif(H5PY_NOT_AVAIL, reason="h5py dependency not available")
+# @pytest.mark.skipif(H5PY_NOT_AVAIL, reason="h5py dependency not available")
 @pytest.mark.skip(
     reason="TODO: Function need updating to not use rios.imagereader.ImageReader"
 )
@@ -1349,7 +1349,7 @@ def test_extract_ref_chip_zone_image_band_values_to_hdf_no_rot(tmp_path):
     assert os.path.exists(out_h5_file)
 
 
-#@pytest.mark.skipif(H5PY_NOT_AVAIL, reason="h5py dependency not available")
+# @pytest.mark.skipif(H5PY_NOT_AVAIL, reason="h5py dependency not available")
 @pytest.mark.skip(
     reason="TODO: Function need updating to not use rios.imagereader.ImageReader"
 )


### PR DESCRIPTION
Primarily, this has been about removing rios.imagereader.ImageReader which has been deprecated from commonly used functions. There are still a few functions using rios.imagereader.ImageReader but these are some function which were written to support deep learning approaches of classification and are not being  extensively used at present.

Also a number of other code improves from ruff.